### PR TITLE
Add compatibity layer to support GHC<7.4 (<> was added in 7.4)

### DIFF
--- a/core/Test/Tasty/CmdLine.hs
+++ b/core/Test/Tasty/CmdLine.hs
@@ -17,6 +17,7 @@ import Test.Tasty.Core
 import Test.Tasty.CoreOptions
 import Test.Tasty.Ingredients
 import Test.Tasty.Options
+import Test.Tasty.Compat.Monoid
 
 -- | Generate a command line parser from a list of option descriptions
 optionParser :: [OptionDescription] -> Parser OptionSet

--- a/core/Test/Tasty/Compat/Monoid.hs
+++ b/core/Test/Tasty/Compat/Monoid.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE CPP #-}
+module Test.Tasty.Compat.Monoid
+  ( (<>)
+  ) where
+
+import Data.Monoid
+
+#if !MIN_VERSION_base(4,5,0)
+infixr 6 <>
+-- | An infix synonym for 'mappend'.
+(<>) :: Monoid m => m -> m -> m
+(<>) = mappend
+{-# INLINE (<>) #-}
+#endif

--- a/core/Test/Tasty/Ingredients/ListTests.hs
+++ b/core/Test/Tasty/Ingredients/ListTests.hs
@@ -13,6 +13,7 @@ import Data.Tagged
 import Test.Tasty.Core
 import Test.Tasty.Options
 import Test.Tasty.Ingredients
+import Test.Tasty.Compat.Monoid
 
 -- | This option, when set to 'True', specifies that we should run in the
 -- «list tests» mode

--- a/core/Test/Tasty/Options.hs
+++ b/core/Test/Tasty/Options.hs
@@ -28,6 +28,8 @@ import Data.Monoid
 import Options.Applicative
 import Options.Applicative.Types
 
+import Test.Tasty.Compat.Monoid
+
 -- | An option is a data type that inhabits the `IsOption` type class.
 class Typeable v => IsOption v where
   -- | The value to use if the option was not supplied explicitly

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -40,6 +40,7 @@ library
     Test.Tasty.Ingredients.ConsoleReporter
     Test.Tasty.Ingredients.ListTests
     Test.Tasty.Ingredients.IncludingOptions
+    Test.Tasty.Compat.Monoid
   build-depends:
     base >= 4.5 && < 5,
     stm >= 2.3,


### PR DESCRIPTION
Use of `<>` make tasty unbuidable for GHC<7.4.

I've caught it on travis-Ci. So maybe it makes sence to add support for multiple GHC versions? https://github.com/hvr/multi-ghc-travis
