### PR TITLE
Add `resultException` to retrive potential exceptions from test results

### DIFF
--- a/core/Test/Tasty/Core.hs
+++ b/core/Test/Tasty/Core.hs
@@ -59,12 +59,19 @@ resultSuccessful r =
     Success -> True
     Failure {} -> False
 
--- | Get 'Just' 'SomeException' if a test threw it, 'Nothing' otherwise.
+-- | Get the 'SomeException' if a test threw it.
 resultException :: Result -> Maybe SomeException
 resultException r =
   case resultOutcome r of
     Failure (TestThrewException e) -> Just e
     _ -> Nothing
+
+-- | 'True' for a test that timed out.
+resultTimedOut :: Result -> Bool
+resultTimedOut r =
+  case resultOutcome r of
+    Failure (TestTimedOut {}) -> True
+    _ -> False
 
 -- | Shortcut for creating a 'Result' that indicates exception
 exceptionResult :: SomeException -> Result

--- a/core/Test/Tasty/Runners.hs
+++ b/core/Test/Tasty/Runners.hs
@@ -35,6 +35,7 @@ module Test.Tasty.Runners
   , FailureReason(..)
   , resultSuccessful
   , resultException
+  , resultTimedOut
   , Progress(..)
   , StatusMap
   , launchTestTree


### PR DESCRIPTION
I could do it with the `maybe` from `generic-maybe`, but in the end thought it was simpler to just imitated `resultSuccessful`.
