### PR TITLE
Add support for QuickCheck 2.7

### DIFF
--- a/quickcheck/Test/Tasty/QuickCheck.hs
+++ b/quickcheck/Test/Tasty/QuickCheck.hs
@@ -27,11 +27,11 @@ import Test.QuickCheck hiding -- for re-export
   , verbose
   , Gen
   )
+import Test.QuickCheck.Random (QCGen)
 import Data.Typeable
 import Data.Proxy
 import Data.List
 import Text.Printf
-import System.Random
 import Control.Applicative
 
 newtype QC = QC QC.Property
@@ -46,7 +46,7 @@ newtype QuickCheckTests = QuickCheckTests Int
   deriving (Num, Ord, Eq, Real, Enum, Integral, Typeable)
 
 -- | Replay a previous test using a replay token
-newtype QuickCheckReplay = QuickCheckReplay (Maybe (StdGen, Int))
+newtype QuickCheckReplay = QuickCheckReplay (Maybe (QCGen, Int))
   deriving (Typeable)
 
 -- | Size of the biggest test cases

--- a/quickcheck/tasty-quickcheck.cabal
+++ b/quickcheck/tasty-quickcheck.cabal
@@ -24,6 +24,6 @@ library
   exposed-modules:     Test.Tasty.QuickCheck
   -- other-modules:       
   other-extensions:    GeneralizedNewtypeDeriving, DeriveDataTypeable
-  build-depends:       base == 4.*, tasty >= 0.8, QuickCheck >= 2.5 && < 3, tagged, random
+  build-depends:       base == 4.*, tasty >= 0.8, QuickCheck >= 2.7 && < 3, tagged
   -- hs-source-dirs:      
   default-language:    Haskell2010


### PR DESCRIPTION
According to QuickCheck changelog: The Gen monad now uses an abstract type QCGen rather than StdGen.
