### PR TITLE
Fixed bug with expectFailure in tasty-quickcheck

### DIFF
--- a/quickcheck/Test/Tasty/QuickCheck.hs
+++ b/quickcheck/Test/Tasty/QuickCheck.hs
@@ -115,7 +115,7 @@ instance IsTest QC where
 
     return $
       (if successful r then testPassed else testFailed)
-      (if unexpected r && showReplay
+      (if isFailure r && showReplay
          then QC.output r ++ reproduceMsg r
          else QC.output r
       )
@@ -131,6 +131,12 @@ unexpected r =
   case r of
     QC.Failure {} -> True
     QC.NoExpectedFailure {} -> True
+    _ -> False
+
+isFailure :: QC.Result -> Bool
+isFailure r =
+  case r of
+    QC.Failure {} -> True
     _ -> False
 
 reproduceMsg :: QC.Result -> String


### PR DESCRIPTION
expectFailure in combination with testProperty throws the following exception:

```
FAIL
  message threw an exception: No match in record selector usedSize
```

The way I see it, there is no way to reproduce unexpected non-failure, so Tasty cannot possibly output a reproduce message. Therefore, I propose to only output the reproduce message on actual Failures, not NoExpectedFailures.
