### PR TITLE
Patches for GHC 9.4

### DIFF
--- a/core/Control/Concurrent/Async.hs
+++ b/core/Control/Concurrent/Async.hs
@@ -266,4 +266,4 @@ catchAll = Control.Exception.catch
 {-# INLINE rawForkIO #-}
 rawForkIO :: IO () -> IO ThreadId
 rawForkIO action = IO $ \ s ->
-   case (fork# action s) of (# s1, tid #) -> (# s1, ThreadId tid #)
+   case (fork# (unIO action) s) of (# s1, tid #) -> (# s1, ThreadId tid #)

--- a/core/Test/Tasty/Patterns/Eval.hs
+++ b/core/Test/Tasty/Patterns/Eval.hs
@@ -6,7 +6,7 @@ import Control.Monad.Reader
 import Control.Monad.Error.Class (throwError) -- see #201
 import qualified Data.Sequence as Seq
 import Data.Foldable
-import Data.List
+import Data.List hiding (length)
 import Data.Maybe
 import Data.Char
 import Test.Tasty.Patterns.Types


### PR DESCRIPTION
GHC 9.4 is not coming any time soon, but patches are tiny and fully backward compatible (see https://travis-ci.com/github/Bodigrim/tasty/builds/231156026), so I guess it should not hurt to merge them early. Sometimes it is important to run tests on bleeding-edge GHC.

Cf. https://gitlab.haskell.org/ghc/head.hackage/-/blob/master/patches/tasty-1.4.1.patch
CC @RyanGlScott 