### PR TITLE
Tasty progress reporting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
         core-tests/resource-release-test.sh
 
     - name: Haddock
-      if: matrix.ghc != '8.0' && matrix.ghc != '8.2'
+      if: matrix.ghc != '8.0' && matrix.ghc != '8.2' && matrix.ghc != '8.4'
       run: cabal haddock all
 
   build-wasi:

--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ your test suite with the `--help` flag. The output will look something like this
 % ./test --help
 Mmm... tasty test suite
 
-Usage: test [-p|--pattern PATTERN] [-t|--timeout DURATION] [-l|--list-tests]
-            [-j|--num-threads NUMBER] [-q|--quiet] [--hide-successes]
-            [--color never|always|auto] [--ansi-tricks ARG]
+Usage: test [-p|--pattern PATTERN] [-t|--timeout DURATION] [--no-progress]
+            [-l|--list-tests] [-j|--num-threads NUMBER] [-q|--quiet]
+            [--hide-successes] [--color never|always|auto] [--ansi-tricks ARG]
             [--smallcheck-depth NUMBER] [--smallcheck-max-count NUMBER]
             [--quickcheck-tests NUMBER] [--quickcheck-replay SEED]
             [--quickcheck-show-replay] [--quickcheck-max-size NUMBER]
@@ -206,6 +206,7 @@ Available options:
                            expression
   -t,--timeout DURATION    Timeout for individual tests (suffixes: ms,s,m,h;
                            default: s)
+  --no-progress            Do not show progress
   -l,--list-tests          Do not run the tests; just print their names
   -j,--num-threads NUMBER  Number of threads to use for tests execution
                            (default: # of cores/capabilities)

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -11,7 +11,8 @@ _YYYY-MM-DD_
 * Dependencies can now be defined pattern-free with `sequentialTestGroup` ([#343](https://github.com/UnkindPartition/tasty/issues/343)).
 * Added `--min-duration-to-report` flag that specifies the time a test must take before `tasty` outputs timing information ([#341](https://github.com/UnkindPartition/tasty/issues/341)).
 * When a test failed with an exception, print it using `displayException` instead of `show` ([#330](https://github.com/UnkindPartition/tasty/issues/330)).
-* `PrintTest` constructor has extra field used to report progress.
+* `PrintTest` constructor now has an extra field used to report progress.
+  Supply `const (pure ())` as this extra field value if you want to skip progress reporting.
 * Progress reporting is no longer ignored.
 
 Version 1.4.3

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -11,6 +11,8 @@ _YYYY-MM-DD_
 * Dependencies can now be defined pattern-free with `sequentialTestGroup` ([#343](https://github.com/UnkindPartition/tasty/issues/343)).
 * Added `--min-duration-to-report` flag that specifies the time a test must take before `tasty` outputs timing information ([#341](https://github.com/UnkindPartition/tasty/issues/341)).
 * When a test failed with an exception, print it using `displayException` instead of `show` ([#330](https://github.com/UnkindPartition/tasty/issues/330)).
+* `PrintTest` constructor has extra field used to report progress.
+* Progress reporting is no longer ignored.
 
 Version 1.4.3
 ---------------

--- a/core/Test/Tasty/Core.hs
+++ b/core/Test/Tasty/Core.hs
@@ -11,6 +11,7 @@ module Test.Tasty.Core
   , resultSuccessful
   , exceptionResult
   , Progress(..)
+  , emptyProgress
   , IsTest(..)
   , TestName
   , ResourceSpec(..)
@@ -181,7 +182,14 @@ data Progress = Progress
   }
   deriving
   ( Show -- ^ @since 1.2
+  , Eq   -- ^ @since 1.5
   )
+
+-- | Empty progress
+--
+-- @since 1.5
+emptyProgress :: Progress
+emptyProgress = Progress mempty 0.0
 
 -- | The interface to be implemented by a test provider.
 --
@@ -201,9 +209,6 @@ class Typeable t => IsTest t where
     :: OptionSet -- ^ options
     -> t -- ^ the test to run
     -> (Progress -> IO ()) -- ^ a callback to report progress.
-                           -- Note: the callback is a no-op at the moment
-                           -- and there are no plans to use it;
-                           -- feel free to ignore this argument for now.
     -> IO Result
 
   -- | The list of options that affect execution of tests of this type

--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -150,15 +150,18 @@ buildTestOutput opts tree =
         printTestProgress progress | progress == emptyProgress
                                    = pure ()
         printTestProgress progress =
-          let
-            msg = case (progressText progress, 100 * progressPercent progress) of
-                    ("",  pct) -> printf "%.0f%%" pct
-                    (txt, 0.0) -> printf "%s" txt
-                    (txt, pct) -> printf "%s : %.0f%%" txt pct
-          in do
-            setCursorColumn resultPosition
-            infoOk msg
-            hFlush stdout
+          case lookupOption opts of
+            HideProgress True  -> pure ()
+            HideProgress False -> 
+              let
+                msg = case (progressText progress, 100 * progressPercent progress) of
+                        ("",  pct) -> printf "%.0f%%" pct
+                        (txt, 0.0) -> printf "%s" txt
+                        (txt, pct) -> printf "%s : %.0f%%" txt pct
+              in do
+                setCursorColumn resultPosition
+                infoOk msg
+                hFlush stdout
 
         printTestResult result = do
           rDesc <- formatMessage $ resultDescription result

--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -153,9 +153,9 @@ buildTestOutput opts tree =
           | otherwise = do
               let
                 msg = case (cleanupProgressText $ progressText progress, 100 * progressPercent progress) of
-                        ("",  pct) -> printf "%.0f%%" pct
+                        ("",  pct) -> printf "%.0f%% " pct
                         (txt, 0.0) -> printf "%s" txt
-                        (txt, pct) -> printf "%s: %.0f%%" txt pct
+                        (txt, pct) -> printf "%s: %.0f%% " txt pct
               setCursorColumn resultPosition
               infoOk msg
               hFlush stdout

--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -76,20 +76,28 @@ import Data.Foldable (foldMap)
 --
 -- @since 0.12
 data TestOutput
-  = PrintTest
-      {- test name           -} String
-      {- print test name     -} (IO ())
-      {- print test progress -} (Progress -> IO ())
-      {- print test result   -} (Result -> IO ())
-      -- ^ Name of a test, an action that prints the test name, and an action
-      -- that renders the result of the action.
-      --
-      -- @since 1.5
-  | PrintHeading String (IO ()) TestOutput
-      -- ^ Name of a test group, an action that prints the heading of a test
-      -- group and the 'TestOutput' for that test group.
-  | Skip -- ^ Inactive test (e.g. not matching the current pattern)
-  | Seq TestOutput TestOutput -- ^ Two sets of 'TestOutput' on the same level
+  = -- | Printing a test.
+    PrintTest
+      String
+        -- ^ Name of the test.
+      (IO ())
+        -- ^ Action that prints the test name.
+      (Progress -> IO ())
+        -- ^ Action that prints the progress of the test.  /Since: 1.5/
+      (Result -> IO ())
+        -- ^ Action that renders the result of the test.
+  | -- | Printing a test group.
+    PrintHeading
+      String
+        -- ^ Name of the test group
+      (IO ())
+        -- ^ Action that prints the heading of a test group.
+      TestOutput
+        -- ^ The 'TestOutput' for that test group.
+  | -- | Inactive test (e.g. not matching the current pattern).
+    Skip
+  | -- | Two sets of 'TestOutput' on the same level.
+    Seq TestOutput TestOutput
 
 -- The monoid laws should hold observationally w.r.t. the semantics defined
 -- in this module.

--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -79,9 +79,12 @@ data TestOutput
   = PrintTest
       {- test name         -} String
       {- print test name   -} (IO ())
+      {- print test progress -} (Progress -> IO ())
       {- print test result -} (Result -> IO ())
       -- ^ Name of a test, an action that prints the test name, and an action
       -- that renders the result of the action.
+      --
+      -- @since 1.5
   | PrintHeading String (IO ()) TestOutput
       -- ^ Name of a test group, an action that prints the heading of a test
       -- group and the 'TestOutput' for that test group.
@@ -103,8 +106,8 @@ instance Monoid TestOutput where
 applyHook :: ([TestName] -> Result -> IO Result) -> TestOutput -> TestOutput
 applyHook hook = go []
   where
-    go path (PrintTest name printName printResult) =
-      PrintTest name printName (printResult <=< hook (name : path))
+    go path (PrintTest name printName printProgress printResult) =
+      PrintTest name printName printProgress (printResult <=< hook (name : path))
     go path (PrintHeading name printName printBody) =
       PrintHeading name printName (go (name : path) printBody)
     go path (Seq a b) = Seq (go path a) (go path b)
@@ -131,10 +134,31 @@ buildTestOutput opts tree =
       level <- ask
 
       let
+        postNamePadding = alignment - indentSize * level - stringWidth name
+
+        testNamePadded = printf "%s%s: %s"
+          (indent level)
+          name
+          (replicate postNamePadding ' ')
+
+        resultPosition = length testNamePadded
+
         printTestName = do
-          printf "%s%s: %s" (indent level) name
-            (replicate (alignment - indentSize * level - stringWidth name) ' ')
+          putStr testNamePadded
           hFlush stdout
+
+        printTestProgress progress | progress == emptyProgress
+                                   = pure ()
+        printTestProgress progress =
+          let
+            msg = case (progressText progress, 100 * progressPercent progress) of
+                    ("",  pct) -> printf "%.0f%%" pct
+                    (txt, 0.0) -> printf "%s" txt
+                    (txt, pct) -> printf "%s : %.0f%%" txt pct
+          in do
+            setCursorColumn resultPosition
+            infoOk msg
+            hFlush stdout
 
         printTestResult result = do
           rDesc <- formatMessage $ resultDescription result
@@ -147,6 +171,10 @@ buildTestOutput opts tree =
                 Failure TestDepFailed -> skipped
                 _ -> fail
             time = resultTime result
+
+          setCursorColumn resultPosition
+          clearFromCursorToLineEnd
+
           printFn (resultShortDescription result)
           when (floor (time * 1e6) >= minDurationMicros) $
             printFn (printf " (%.2fs)" time)
@@ -158,7 +186,7 @@ buildTestOutput opts tree =
           case resultDetailsPrinter result of
             ResultDetailsPrinter action -> action level withConsoleFormat
 
-      return $ PrintTest name printTestName printTestResult
+      return $ PrintTest name printTestName printTestProgress printTestResult
 
     runGroup :: OptionSet -> TestName -> [Ap (Reader Level) TestOutput] -> Ap (Reader Level) TestOutput
     runGroup _opts name grp = Ap $ do
@@ -194,15 +222,17 @@ foldTestOutput
   -> b
 foldTestOutput foldTest foldHeading outputTree smap =
   flip evalState 0 $ getApp $ go outputTree where
-  go (PrintTest name printName printResult) = Ap $ do
+
+  go (PrintTest name printName printProgress printResult) = Ap $ do
     ix <- get
     put $! ix + 1
     let
       statusVar =
         fromMaybe (error "internal error: index out of bounds") $
         IntMap.lookup ix smap
-      readStatusVar = getResultFromTVar statusVar
-    return $ foldTest name printName readStatusVar printResult
+
+    return $ foldTest name printName (ppProgressOrResult statusVar printProgress) printResult
+
   go (PrintHeading name printName printBody) = Ap $
     foldHeading name printName <$> getApp (go printBody)
   go (Seq a b) = mappend (go a) (go b)
@@ -213,6 +243,17 @@ foldTestOutput foldTest foldHeading outputTree smap =
 --------------------------------------------------
 -- TestOutput modes
 --------------------------------------------------
+
+ppProgressOrResult :: TVar Status -> (Progress -> IO ()) -> IO Result
+ppProgressOrResult statusVar ppProgress = go where
+  go = either (\p -> ppProgress p *> go) return =<< (atomically $ do
+    status <- readTVar statusVar 
+    case status of
+      Executing p -> pure $ Left p
+      Done r      -> pure $ Right r
+      _           -> retry
+    )
+
 -- {{{
 consoleOutput :: (?colors :: Bool) => TestOutput -> StatusMap -> IO ()
 consoleOutput toutput smap =

--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -77,10 +77,10 @@ import Data.Foldable (foldMap)
 -- @since 0.12
 data TestOutput
   = PrintTest
-      {- test name         -} String
-      {- print test name   -} (IO ())
+      {- test name           -} String
+      {- print test name     -} (IO ())
       {- print test progress -} (Progress -> IO ())
-      {- print test result -} (Result -> IO ())
+      {- print test result   -} (Result -> IO ())
       -- ^ Name of a test, an action that prints the test name, and an action
       -- that renders the result of the action.
       --
@@ -270,7 +270,8 @@ consoleOutput toutput smap =
       , Any True)
     foldHeading _name printHeading (printBody, Any nonempty) =
       ( Traversal $ do
-          when nonempty $ do printHeading :: IO (); getTraversal printBody
+          when nonempty $ printHeading
+          getTraversal printBody
       , Any nonempty
       )
 

--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -153,7 +153,7 @@ buildTestOutput opts tree =
 
           | otherwise = do
               let
-                msg = case (progressText progress, 100 * progressPercent progress) of
+                msg = case (cleanupProgressText $ progressText progress, 100 * progressPercent progress) of
                         ("",  pct) -> printf "%.0f%%" pct
                         (txt, 0.0) -> printf "%s" txt
                         (txt, pct) -> printf "%s: %.0f%%" txt pct
@@ -205,6 +205,13 @@ buildTestOutput opts tree =
           , foldGroup = runGroup
           }
           opts tree
+
+-- | Make sure the progress text does not contain any newlines or line feeds,
+-- lest our ANSI magic breaks. Since the progress text is expected to be short,
+-- we simply drop anything after a newline.
+cleanupProgressText :: String -> String
+cleanupProgressText = map (\c -> if isSpace c then ' ' else c)
+                    . takeWhile (\c -> c /= '\n' && c /= '\r' && c /= '\t')
 
 -- | Fold function for the 'TestOutput' tree into a 'Monoid'.
 --

--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -253,11 +253,13 @@ foldTestOutput foldTest foldHeading outputTree smap =
 --------------------------------------------------
 
 ppProgressOrResult :: TVar Status -> (Progress -> IO ()) -> IO Result
-ppProgressOrResult statusVar ppProgress = go where
-  go = either (\p -> ppProgress p *> go) return =<< (atomically $ do
+ppProgressOrResult statusVar ppProgress = go emptyProgress where
+  go old_p = either (\p -> ppProgress p *> go p) return =<< (atomically $ do
     status <- readTVar statusVar
     case status of
-      Executing p -> pure $ Left p
+      Executing p
+        | p == old_p -> retry
+        | otherwise -> pure $ Left p
       Done r      -> pure $ Right r
       _           -> retry
     )

--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -148,8 +148,7 @@ buildTestOutput opts tree =
           hFlush stdout
 
         printTestProgress progress
-          | getHideProgress (lookupOption opts ) ||
-            progress == emptyProgress = pure ()
+          | progress == emptyProgress = pure ()
 
           | otherwise = do
               let

--- a/core/Test/Tasty/Options/Core.hs
+++ b/core/Test/Tasty/Options/Core.hs
@@ -5,6 +5,7 @@ module Test.Tasty.Options.Core
   ( NumThreads(..)
   , Timeout(..)
   , mkTimeout
+  , HideProgress(..)
   , coreOptions
   -- * Helpers
   , parseDuration
@@ -97,6 +98,18 @@ mkTimeout n =
   Timeout n $
     showFixed True (fromInteger n / (10^6) :: Micro) ++ "s"
 
+-- | Hide progress information.
+--
+-- @since 1.5
+newtype HideProgress = HideProgress { getHideProgress :: Bool }
+  deriving (Eq, Ord, Typeable)
+instance IsOption HideProgress where
+    defaultValue = HideProgress False
+    parseValue = fmap HideProgress . safeReadBool
+    optionName = return "hide-progress"
+    optionHelp = return "Do not show progress"
+    optionCLParser = mkFlagCLParser mempty (HideProgress True)
+
 -- | The list of all core options, i.e. the options not specific to any
 -- provider or ingredient, but to tasty itself. Currently contains
 -- 'TestPattern' and 'Timeout'.
@@ -106,4 +119,5 @@ coreOptions :: [OptionDescription]
 coreOptions =
   [ Option (Proxy :: Proxy TestPattern)
   , Option (Proxy :: Proxy Timeout)
+  , Option (Proxy :: Proxy HideProgress)
   ]

--- a/core/Test/Tasty/Options/Core.hs
+++ b/core/Test/Tasty/Options/Core.hs
@@ -98,7 +98,10 @@ mkTimeout n =
   Timeout n $
     showFixed True (fromInteger n / (10^6) :: Micro) ++ "s"
 
--- | Hide progress information.
+-- | Hide progress information. If progress disabled, the test launcher
+-- 'Test.Tasty.Runners.launchTestTree' completely ignores callbacks to update progress.
+-- If enabled, it's up to individual 'Test.Tasty.Ingredients.TestReporter's
+-- how to execute, some might not be able to render progress anyways.
 --
 -- @since 1.5
 newtype HideProgress = HideProgress { getHideProgress :: Bool }

--- a/core/Test/Tasty/Run.hs
+++ b/core/Test/Tasty/Run.hs
@@ -112,7 +112,7 @@ executeTest
   -> Seq Finalizer -- ^ finalizers (to be executed in this order)
   -> IO ()
 executeTest action statusVar timeoutOpt inits fins = mask $ \restore -> do
-  resultOrExn <- try $ restore $ do
+  resultOrExn <- try . restore $ do
     -- N.B. this can (re-)throw an exception. It's okay. By design, the
     -- actual test will not be run, then. We still run all the
     -- finalizers.

--- a/core/Test/Tasty/Runners.hs
+++ b/core/Test/Tasty/Runners.hs
@@ -39,6 +39,7 @@ module Test.Tasty.Runners
   , FailureReason(..)
   , resultSuccessful
   , Progress(..)
+  , emptyProgress
   , StatusMap
   , launchTestTree
   , NumThreads(..)

--- a/quickcheck/CHANGELOG.md
+++ b/quickcheck/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes
 Version 0.10.3
 --------------
 
-* Print quickcheck progress using tasty progress reporting.
+* Print Quickcheck progress using Tasty progress reporting.
 
 
 Version 0.10.2

--- a/quickcheck/CHANGELOG.md
+++ b/quickcheck/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Version 0.10.3
+--------------
+
+* Print quickcheck progress using tasty progress reporting.
+
+
 Version 0.10.2
 --------------
 

--- a/quickcheck/Test/Tasty/QuickCheck.hs
+++ b/quickcheck/Test/Tasty/QuickCheck.hs
@@ -237,6 +237,8 @@ quickCheck :: (Progress -> IO ())
            -> QC.Property
            -> IO QC.Result
 quickCheck yieldProgress args prop = do
+  -- Here we rely on the fact that QuickCheck currently prints its progress to
+  -- stderr and the overall status (which we don't need) to stdout
   tm <- QC.newTerminal
           (const $ pure ())
           (\progressText -> yieldProgress emptyProgress { progressText = parseProgress progressText })

--- a/quickcheck/Test/Tasty/QuickCheck.hs
+++ b/quickcheck/Test/Tasty/QuickCheck.hs
@@ -205,8 +205,6 @@ instance IsTest QC where
 
   run opts (QC prop) yieldProgress = do
     (replaySeed, args) <- optionSetToArgs opts
-    -- This IORef contains the number of examples tested so far,
-    -- for displaying progress.
     let
       QuickCheckShowReplay showReplay = lookupOption opts
       QuickCheckVerbose    verbose    = lookupOption opts

--- a/quickcheck/Test/Tasty/QuickCheck.hs
+++ b/quickcheck/Test/Tasty/QuickCheck.hs
@@ -1,5 +1,5 @@
 -- | This module allows to use QuickCheck properties in tasty.
-{-# LANGUAGE GeneralizedNewtypeDeriving, DeriveDataTypeable #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, DeriveDataTypeable, NamedFieldPuns #-}
 module Test.Tasty.QuickCheck
   ( testProperty
   , testProperties
@@ -24,7 +24,10 @@ import Test.Tasty ( testGroup )
 import Test.Tasty.Providers
 import Test.Tasty.Options
 import qualified Test.QuickCheck as QC
-import Test.Tasty.Runners (formatMessage)
+import qualified Test.QuickCheck.Test as QC
+import qualified Test.QuickCheck.State as QC
+import qualified Test.QuickCheck.Text as QC
+import Test.Tasty.Runners (formatMessage, emptyProgress)
 import Test.QuickCheck hiding -- for re-export
   ( quickCheck
   , Args(..)
@@ -47,6 +50,7 @@ import Test.QuickCheck hiding -- for re-export
   , verboseCheckAll
   )
 
+import qualified Data.Char as Char
 import Data.Typeable
 import Data.List
 import Text.Printf
@@ -199,20 +203,20 @@ instance IsTest QC where
     , Option (Proxy :: Proxy QuickCheckMaxShrinks)
     ]
 
-  run opts (QC prop) _yieldProgress = do
+  run opts (QC prop) yieldProgress = do
     (replaySeed, args) <- optionSetToArgs opts
-
+    -- This IORef contains the number of examples tested so far,
+    -- for displaying progress.
     let
       QuickCheckShowReplay showReplay = lookupOption opts
       QuickCheckVerbose    verbose    = lookupOption opts
       maxSize = QC.maxSize args
-      testRunner = if verbose
-                     then QC.verboseCheckWithResult
-                     else QC.quickCheckWithResult
       replayMsg = makeReplayMsg replaySeed maxSize
 
     -- Quickcheck already catches exceptions, no need to do it here.
-    r <- testRunner args prop
+    r <- quickCheck yieldProgress
+                    args
+                    (if verbose then QC.verbose prop else prop)
 
     qcOutput <- formatMessage $ QC.output r
     let qcOutputNl =
@@ -225,6 +229,25 @@ instance IsTest QC where
       (if testSuccessful then testPassed else testFailed)
       (qcOutputNl ++
         (if putReplayInDesc then replayMsg else ""))
+
+
+-- | Like the original 'QC.quickCheck' but is reporting progress using tasty
+-- callback.
+--
+quickCheck :: (Progress -> IO ())
+           -> QC.Args
+           -> QC.Property
+           -> IO QC.Result
+quickCheck yieldProgress args prop = do
+  tm <- QC.newTerminal
+          (const $ pure ())
+          (\progressText -> yieldProgress emptyProgress { progressText = parseProgress progressText })
+  QC.withState args $ \ s ->
+    QC.test s { QC.terminal = tm } prop
+  where
+    parseProgress :: String -> String
+    parseProgress = takeWhile Char.isDigit
+                  . dropWhile (not . Char.isDigit)
 
 successful :: QC.Result -> Bool
 successful r =

--- a/quickcheck/tasty-quickcheck.cabal
+++ b/quickcheck/tasty-quickcheck.cabal
@@ -46,7 +46,7 @@ test-suite test
     test.hs
   build-depends:
       base >= 4.7 && < 5
-    , tasty
+    , tasty >= 1.5
     , tasty-quickcheck
     , tasty-hunit
     , pcre-light

--- a/quickcheck/tasty-quickcheck.cabal
+++ b/quickcheck/tasty-quickcheck.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-quickcheck
-version:             0.10.2
+version:             0.10.3
 synopsis:            QuickCheck support for the Tasty test framework.
 description:         QuickCheck support for the Tasty test framework.
 license:             MIT


### PR DESCRIPTION
This PR is an updated and cleaned version of #245.

The upstream version introduced a bug which prevented quickcheck properties to
be shrinked.  The approach in this PR avoids that by using QuickCheck
facilities to print its own progress using tasty progress callback.

- Progress reporting ability.
- quickcheck: print progress
- Added  --no-progress option
- clean code
