### PR TITLE
Added support for Hpc coverage per test

### DIFF
--- a/core-tests/core-tests-hpc.sh
+++ b/core-tests/core-tests-hpc.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+shopt -s globstar
+
+HPC_DIR=core-tests-hpc
+HTML_DIR=core-tests-hpc-html
+HPCPP=../../hpcpp/dist-newstyle/build/x86_64-linux/ghc-8.10.2/hpc-bin-0.68.1/x/hpc/build/hpc/hpc
+
+BUILD=../dist-newstyle/build/x86_64-linux/ghc-8.10.2
+
+TASTY_TESTS_SRC=.
+TASTY_TESTS_HPC=$BUILD/core-tests-0.1/hpc/vanilla/mix/tasty-core-tests
+
+TASTY_SRC=../core
+TASTY_HPC=$BUILD/tasty-1.4.2/hpc/dyn/mix/tasty-1.4.2
+
+TASTY_QUICKCHECK_SRC=../quickcheck
+TASTY_QUICKCHECK_HPC=$BUILD/tasty-quickcheck-0.10.1.1/hpc/dyn/mix/tasty-quickcheck-0.10.1.1
+
+TASTY_HUNIT_SRC=../hunit
+TASTY_HUNIT_HPC=$BUILD/tasty-hunit-0.10.0.2/hpc/dyn/mix/tasty-hunit-0.10.0.2
+
+cabal clean
+cabal configure --enable-tests --enable-coverage
+cabal build
+cabal exec tasty-core-tests -- --save-tix ${HPC_DIR}
+
+$HPCPP markup-multi \
+  --hpcdir ${TASTY_HPC}            --srcdir ${TASTY_SRC} \
+  --hpcdir ${TASTY_HUNIT_HPC}      --srcdir ${TASTY_HUNIT_SRC} \
+  --hpcdir ${TASTY_QUICKCHECK_HPC} --srcdir ${TASTY_QUICKCHECK_SRC} \
+  --hpcdir ${TASTY_TESTS_HPC}      --srcdir ${TASTY_TESTS_SRC} \
+  --destdir ${HTML_DIR} \
+  ${HPC_DIR}/**/*.tix
+

--- a/core-tests/core-tests.cabal
+++ b/core-tests/core-tests.cabal
@@ -26,16 +26,6 @@ executable tasty-core-tests
   default-extensions:  CPP, NumDecimals
   ghc-options:         -Wall -fno-warn-type-defaults -threaded -fno-warn-name-shadowing
 
-test-suite tasty-core-testsuite
-  type:                exitcode-stdio-1.0
-  main-is:             test.hs
-  other-modules:       Resources, Timeouts, Utils, AWK, Dependencies
-  build-depends:       base >= 4.9 && <= 5, tasty, tasty-hunit, tasty-golden, tasty-quickcheck, containers, stm, mtl,
-                       filepath, bytestring, optparse-applicative
-  default-language:    Haskell2010
-  default-extensions:  CPP, NumDecimals
-  ghc-options:         -Wall -fno-warn-type-defaults -threaded -fno-warn-name-shadowing
-
 executable exit-status-test
   main-is:             exit-status-test.hs
   build-depends:       base <= 5, tasty, tasty-hunit,

--- a/core-tests/core-tests.cabal
+++ b/core-tests/core-tests.cabal
@@ -26,6 +26,16 @@ executable tasty-core-tests
   default-extensions:  CPP, NumDecimals
   ghc-options:         -Wall -fno-warn-type-defaults -threaded -fno-warn-name-shadowing
 
+test-suite tasty-core-testsuite
+  type:                exitcode-stdio-1.0
+  main-is:             test.hs
+  other-modules:       Resources, Timeouts, Utils, AWK, Dependencies
+  build-depends:       base >= 4.9 && <= 5, tasty, tasty-hunit, tasty-golden, tasty-quickcheck, containers, stm, mtl,
+                       filepath, bytestring, optparse-applicative
+  default-language:    Haskell2010
+  default-extensions:  CPP, NumDecimals
+  ghc-options:         -Wall -fno-warn-type-defaults -threaded -fno-warn-name-shadowing
+
 executable exit-status-test
   main-is:             exit-status-test.hs
   build-depends:       base <= 5, tasty, tasty-hunit,

--- a/core/Test/Tasty/Hpc.hs
+++ b/core/Test/Tasty/Hpc.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
+-- | Haskell Program Coverage (Hpc) integration
+
+module Test.Tasty.Hpc
+  ( Hpc(..)
+  , defaultHpc
+  , parseHpc
+  ) where
+
+import Test.Tasty.Options
+
+import System.FilePath
+import Data.Typeable
+import Options.Applicative hiding (str)
+
+-- | An option to enable Hpc integration
+-- The FilePath is the output directory for the generated .tix files.
+data Hpc = SaveHpc FilePath | NoHpc
+  deriving (Typeable, Show, Eq)
+
+defaultHpc :: Hpc
+defaultHpc = NoHpc
+
+parseHpc :: String -> Maybe Hpc
+parseHpc path
+  | isValid path = Just (SaveHpc path)
+  | otherwise    = Nothing
+
+instance IsOption Hpc where
+  defaultValue = defaultHpc
+  parseValue = parseHpc
+  optionName = return "save-tix"
+  optionHelp = return "Create one Tix file per test when compiled with Hpc support"
+  optionCLParser = mkOptionCLParser (metavar "TIX_PATH")

--- a/core/Test/Tasty/Options/Core.hs
+++ b/core/Test/Tasty/Options/Core.hs
@@ -21,6 +21,7 @@ import Data.Monoid
 
 import Test.Tasty.Options
 import Test.Tasty.Patterns
+import Test.Tasty.Hpc
 
 -- | Number of parallel threads to use for running tests.
 --
@@ -93,4 +94,5 @@ coreOptions :: [OptionDescription]
 coreOptions =
   [ Option (Proxy :: Proxy TestPattern)
   , Option (Proxy :: Proxy Timeout)
+  , Option (Proxy :: Proxy Hpc)
   ]

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -51,6 +51,8 @@ library
     Test.Tasty.Patterns.Parser
     Test.Tasty.Patterns.Printer
     Test.Tasty.Patterns.Eval
+    -- Hpc integration 
+    Test.Tasty.Hpc
   other-modules:
     Control.Concurrent.Async
     Test.Tasty.Parallel,
@@ -69,6 +71,9 @@ library
     base >= 4.8 && < 5,
     stm >= 2.3,
     containers,
+    hpc,
+    filepath,
+    directory,
     mtl >= 2.1.3.1,
     tagged >= 0.5,
     optparse-applicative >= 0.14,


### PR DESCRIPTION
Hello @UnkindPartition!

I'm opening this PR to discuss a feature I added to `tasty-core`: **Hpc coverage integration that produces individual coverage reports per test.** The motivation for this is that having more granular Hpc reports allows developing some new interesting stuff, e.g.,  [HTML coverage reports with expressions annotated by the tests exercising them](https://imgur.com/a/iVWf9nP) (this was created using [my WIP fork of Hpc](https://github.com/agustinmista/hpcpp)).

The way this works is by wrapping the test runner using a function that clears the internal Hpc coverage vector, runs the test, reflects the Hpc vector to a Haskell value that contains the individual coverage of such test, and saves it to a `.tix` file. These `.tix` files are stored in a destination folder set by the user with the `--save-tix TIX_PATH` CLI option and are structured to follow the test tree hierarchy. E.g., running the following test tree:

```
testGroup "One" [ testGroup "Two" [ testCase "Three" ... ] ]
```

with `--save-tix foo` will create:

```
foo/One/Two/Three.tix
```
 
One possible drawback of this feature is that test should run sequentially so the internal Hpc coverage vector doesn't get mangled with ticks generated by different parallel tests. To account for this, using `--save-tix` implies `NumThreads=1`. 

I also included the script `core-tests/core-tests-hpc.sh` in case you want to try it by yourself. It assumes the existence of my fork of HPC, but you can comment the last command if you don't want to produce an HTML report.

I hope you like this feature! 😄

/Agustín 