### PR TITLE
Bump core to 1.4.2.2; CHANGELOG

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Version 1.4.2.2
+---------------
+
+- Fix compilation with `mtl-2.3`
+- Tested with GHC 8.0 - 9.2; dropped support for GHC 7.x
+
 Version 1.4.2.1
 ---------------
 

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -2,7 +2,7 @@
 --  see http://haskell.org/cabal/users-guide/
 
 name:                tasty
-version:             1.4.2.1
+version:             1.4.2.2
 synopsis:            Modern and extensible testing framework
 description:         Tasty is a modern testing framework for Haskell.
                      It lets you combine your unit tests, golden


### PR DESCRIPTION
Release 1.4.2.2, closing #333.

Oops, just realized that I am not an uploader for this package on hackage.  
One of them, please get in contact, or pick up this PR:
- @ekmett
- @ocharles
- @UnkindPartition
- @bergey
