### PR TITLE
Print dependency cycles in error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The following providers exist:
   (based on [LeanCheck](https://hackage.haskell.org/package/leancheck))
 * [tasty-program](https://hackage.haskell.org/package/tasty-program) — run
   external program and test whether it terminates successfully
-* [tasty-wai](https://hackage.haskell.org/package/tasty-wai) — 
+* [tasty-wai](https://hackage.haskell.org/package/tasty-wai) —
   for testing [wai](https://hackage.haskell.org/wai) endpoints.
 * [tasty-inspection-testing](https://hackage.haskell.org/package/tasty-inspection-testing) —
   for compile-time testing of code properties
@@ -755,7 +755,7 @@ Here are some caveats to keep in mind regarding dependencies in Tasty:
    typos. Fortunately, misspecified dependencies usually lead to test failures
    and so can be detected that way.
 1. Dependencies shouldn't form a cycle, otherwise Tasty with fail with the
-   message "Test dependencies form a loop." A common cause of this is a test
+   message "Test dependencies have cycles." A common cause of this is a test
    matching its own dependency pattern.
 1. Using dependencies may introduce quadratic complexity. Specifically,
    resolving dependencies is *O(number_of_tests × number_of_dependencies)*,
@@ -798,11 +798,11 @@ Here are some caveats to keep in mind regarding dependencies in Tasty:
     See [issue #152](https://github.com/UnkindPartition/tasty/issues/152).
 
 3. **Q**: Patterns with slashes do not work on Windows. How can I fix it?
-  
-   **A**: If you are running Git for Windows terminal, it has a habit of converting slashes 
-   to backslashes. Set `MSYS_NO_PATHCONV=1` to prevent this behaviour, or follow other 
+
+   **A**: If you are running Git for Windows terminal, it has a habit of converting slashes
+   to backslashes. Set `MSYS_NO_PATHCONV=1` to prevent this behaviour, or follow other
    suggestions from [Known Issues](https://github.com/git-for-windows/build-extra/blob/main/ReleaseNotes.md#known-issues).
-   
+
 ## Press
 
 Blog posts and other publications related to tasty. If you wrote or just found

--- a/core-tests/Dependencies.hs
+++ b/core-tests/Dependencies.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedLists #-}
+
 module Dependencies (testDependencies) where
 
 import Test.Tasty
@@ -10,10 +12,12 @@ import Text.Printf
 import qualified Data.IntMap as IntMap
 import Control.Monad
 import Control.Exception
+import Data.List (intercalate)
 
 testDependencies :: TestTree
 testDependencies = testGroup "Dependencies" $
   generalDependencyTests ++
+  [circDepShow] ++
   circDepTests ++
   [resourceDependenciesTest]
 
@@ -25,6 +29,17 @@ testTree deptype succeed =
     , testCase "Two" $ threadDelay 1e6
     , testCase "Three" $ threadDelay 1e6 >> assertBool "fail" succeed
     ]
+
+circDepShow :: TestTree
+circDepShow = testCase "show DependencyLoop" $
+  assertEqual
+    "dependency cycles should be shown on separate lines"
+    (show (DependencyLoop [[["a", "foo"], ["b"]], [["c"], ["d", "bar"]]]))
+    (intercalate "\n"
+      [ "Test dependencies have cycles:"
+      , "- a.foo, b, a.foo"
+      , "- c, d.bar, c"
+      ])
 
 -- an example of a tree with circular dependencies
 circDepTree1 :: TestTree
@@ -40,12 +55,25 @@ circDepTree2 = testGroup "dependency test"
 
 circDepTests :: [TestTree]
 circDepTests = do
-  (i, tree) <- zip [1,2] [circDepTree1, circDepTree2]
+  (i, expectedCycles, tree) <-
+    zip3
+      [1,2]
+      [circDeps1, circDeps2]
+      [circDepTree1, circDepTree2]
+
   return $ testCase ("Circular dependencies " ++ show i) $ do
     r <- try $ launchTestTree mempty tree $ \_ -> return $ \_ -> return ()
     case r of
-      Left DependencyLoop -> return ()
+      Left (DependencyLoop cycles) ->
+        assertEqual "Unexpected cycles" expectedCycles cycles
       _ -> assertFailure $ show r
+  where
+    circDeps1 = [[["One"]]]
+    circDeps2 = [[
+        ["dependency test", "One"]
+      , ["dependency test", "Three"]
+      , ["dependency test", "Two"]
+      ]]
 
 -- | Check the semantics of dependencies
 generalDependencyTests :: [TestTree]

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changes
 =======
 
+Unreleased
+---------------
+
+_YYYY-MM-DD_
+
+- Dependency loop error now lists all test cases that formed a cycle
+
 Version 1.4.2.3
 ---------------
 


### PR DESCRIPTION
While Tasty detects cycles and prints an error message, it does not print the cycles it found. This PR makes sure it does. I've tested it on another code base with cycles in it, the output looks like:

```
clash-testsuite: Test dependencies form a loop:

..tests.shouldwork.Issues.T2046.VHDL.Vivado => ..tests.shouldwork.Issues.T2046.VHDL.Vivado

..tests.shouldwork.Issues.T2046.SystemVerilog.Vivado => ..tests.shouldwork.Issues.T2046.SystemVerilog.Vivado

..tests.shouldwork.BlackBox.T2117.VHDL.Vivado => ..tests.shouldwork.BlackBox.T2117.VHDL.Vivado

..tests.shouldfail.Verification.NonTemporalPSL.VHDL.Vivado => ..tests.shouldfail.Verification.NonTemporalPSL.VHDL.Vivado
```

Note the double dot is an artifact of this particular test tree.