### PR TITLE
Do not depend on unbounded-delays on 64-bit architecture

### DIFF
--- a/core/Test/Tasty/Run.hs
+++ b/core/Test/Tasty/Run.hs
@@ -11,6 +11,7 @@ module Test.Tasty.Run
 import qualified Data.IntMap as IntMap
 import qualified Data.Sequence as Seq
 import qualified Data.Foldable as F
+import Data.Int (Int64)
 import Data.Maybe
 import Data.Graph (SCC(..), stronglyConnComp)
 import Data.Typeable
@@ -21,7 +22,6 @@ import Control.Monad.Trans.Reader (ReaderT(..), local, ask)
 import Control.Monad.Trans.Writer (WriterT(..), execWriterT, mapWriterT, tell)
 import Control.Concurrent
 import Control.Concurrent.STM
-import Control.Concurrent.Timeout (timeout)
 import Control.Concurrent.Async
 import Control.Exception as E
 import Control.Applicative
@@ -29,6 +29,12 @@ import Control.Arrow
 import Data.Monoid (First(..))
 import GHC.Conc (labelThread)
 import Prelude  -- Silence AMP and FTP import warnings
+
+#ifdef MIN_VERSION_unbounded_delays
+import Control.Concurrent.Timeout (timeout)
+#else
+import System.Timeout (timeout)
+#endif
 
 import Test.Tasty.Core
 import Test.Tasty.Parallel
@@ -171,7 +177,9 @@ executeTest action statusVar timeoutOpt inits fins = mask $ \restore -> do
             , resultTime = fromIntegral t
             , resultDetailsPrinter = noResultDetails
             }
-      fromMaybe timeoutResult <$> timeout t a
+      -- If compiled with unbounded-delays then t' :: Integer, otherwise t' :: Int
+      let t' = fromInteger (min (max 0 t) (toInteger (maxBound :: Int64)))
+      fromMaybe timeoutResult <$> timeout t' a
 
     -- destroyResources should not be interrupted by an exception
     -- Here's how we ensure this:

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -70,8 +70,13 @@ library
     transformers         >= 0.5,
     tagged               >= 0.5,
     optparse-applicative >= 0.14,
-    unbounded-delays     >= 0.1,
     ansi-terminal        >= 0.9
+
+  -- No reason to depend on unbounded-delays on 64-bit architecture
+  if(!arch(x86_64) && !arch(aarch64))
+    build-depends:
+      unbounded-delays >= 0.1
+
   if(!impl(ghc >= 8.0))
     build-depends: semigroups
 


### PR DESCRIPTION
On 64-bit arch there is no point to depend on `unbounded-delays`: `(maxBound :: Int)` microseconds are almost 300 000 years. Not a terribly big deal, but shaving off a dependency is always nice. Basically, CI jobs for all packages, which use `tasty`, have one less thing to compile.