### PR TITLE
Do not depend on clock package, decomission clock flag

### DIFF
--- a/core/Test/Tasty/Runners/Utils.hs
+++ b/core/Test/Tasty/Runners/Utils.hs
@@ -7,15 +7,15 @@ import Control.Exception
 import Control.Applicative
 import Control.Concurrent (mkWeakThreadId, myThreadId)
 import Control.Monad (forM_)
-#ifndef VERSION_clock
-import Data.Time.Clock.POSIX (getPOSIXTime)
-#endif
 import Data.Typeable (Typeable)
 import Prelude  -- Silence AMP import warnings
 import Text.Printf
 import Foreign.C (CInt)
-#ifdef VERSION_clock
-import qualified System.Clock as Clock
+
+#if MIN_VERSION_base(4,11,0)
+import GHC.Clock (getMonotonicTime)
+#else
+import Data.Time.Clock.POSIX (getPOSIXTime)
 #endif
 
 -- Install handlers only on UNIX
@@ -102,21 +102,13 @@ timed t = do
   end   <- getTime
   return (end-start, r)
 
-#ifdef VERSION_clock
+#if MIN_VERSION_base(4,11,0)
 -- | Get monotonic time
 --
 -- Warning: This is not the system time, but a monotonically increasing time
 -- that facilitates reliable measurement of time differences.
 getTime :: IO Time
-getTime = do
-  t <- Clock.getTime Clock.Monotonic
-  let ns = realToFrac $
-#if MIN_VERSION_clock(0,7,1)
-        Clock.toNanoSecs t
-#else
-        Clock.timeSpecAsNanoSecs t
-#endif
-  return $ ns / 10 ^ (9 :: Int)
+getTime = getMonotonicTime
 #else
 -- | Get system time
 getTime :: IO Time

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -22,11 +22,6 @@ Source-repository head
   location: git://github.com/UnkindPartition/tasty.git
   subdir:   core
 
-flag clock
-  description:
-    Depend on the clock package for more accurate time measurement
-  default: True
-
 flag unix
   description:
     Depend on the unix package to install signal handlers
@@ -80,10 +75,8 @@ library
   if(!impl(ghc >= 8.0))
     build-depends: semigroups
 
-  if flag(clock) && !impl(ghcjs)
-    build-depends: clock >= 0.4.4.0
-  else
-    build-depends: time  >= 1.4
+  if(!impl(ghc >= 8.4))
+    build-depends: time >= 1.4
 
   if !os(windows) && !impl(ghcjs)
     build-depends: wcwidth


### PR DESCRIPTION
Starting from GHC 8.4 we can use `GHC.Clock` from `base`, and for diminishing minority of users of GHC < 8.4 `time` is sufficiently good (and does not require build, because it is a boot package).