### PR TITLE
Do not depend on wcwidth

### DIFF
--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -79,7 +79,7 @@ library
     build-depends: time >= 1.4
 
   if !os(windows) && !impl(ghcjs)
-    build-depends: wcwidth
+    cpp-options: -DUSE_WCWIDTH
     if flag(unix)
       build-depends: unix
 


### PR DESCRIPTION
We use a single function from `wcwidth`, which we can call directly ourselves.