### PR TITLE
Split foldTestTree

### DIFF
--- a/core/Test/Tasty/Core.hs
+++ b/core/Test/Tasty/Core.hs
@@ -393,10 +393,6 @@ trivialFold = TreeFold
 --
 -- Thus, it is preferred to an explicit recursive traversal of the tree.
 --
--- Note: right now, the patterns are looked up only once, and won't be
--- affected by the subsequent option changes. This shouldn't be a problem
--- in practice; OTOH, this behaviour may be changed later.
---
 -- @since 0.7
 foldTestTree
   :: forall b . Monoid b

--- a/core/Test/Tasty/Core.hs
+++ b/core/Test/Tasty/Core.hs
@@ -1,22 +1,40 @@
 -- | Core types and definitions
-{-# LANGUAGE GeneralizedNewtypeDeriving, FlexibleContexts,
-             ExistentialQuantification, RankNTypes, DeriveDataTypeable, NoMonomorphismRestriction,
-             DeriveGeneric #-}
-module Test.Tasty.Core where
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE RankNTypes #-}
+module Test.Tasty.Core
+  ( FailureReason(..)
+  , Outcome(..)
+  , Time
+  , Result(..)
+  , resultSuccessful
+  , exceptionResult
+  , Progress(..)
+  , IsTest(..)
+  , TestName
+  , ResourceSpec(..)
+  , ResourceError(..)
+  , DependencyType(..)
+  , TestTree(..)
+  , testGroup
+  , after
+  , after_
+  , TreeFold(..)
+  , trivialFold
+  , foldTestTree
+  , treeOptions
+  ) where
 
 import Control.Exception
-import Test.Tasty.Providers.ConsoleFormat
+import qualified Data.Map as Map
+import qualified Data.Sequence as Seq
+import Data.Tagged
+import Data.Typeable
+import GHC.Generics
 import Test.Tasty.Options
 import Test.Tasty.Patterns
 import Test.Tasty.Patterns.Types
-import Data.Foldable
-import qualified Data.Sequence as Seq
-import Data.Monoid
-import Data.Typeable
-import qualified Data.Map as Map
-import Data.Tagged
-import GHC.Generics
-import Prelude  -- Silence AMP and FTP import warnings
+import Test.Tasty.Providers.ConsoleFormat
 import Text.Printf
 
 -- | If a test failed, 'FailureReason' describes why.


### PR DESCRIPTION
https://github.com/UnkindPartition/tasty/blob/0debac85701560e8c96cd3705988c50197cb214e/core/Test/Tasty/Core.hs#L410-L427

At the moment `foldTestTree` does three jobs at once: evaluates options, filters by pattern and actually folds. This PR splits it into three functions, each with its own task. 

This refactoring should hopefully guide a better way for #343, but separating concerns is a good thing anyways.