### PR TITLE
Refactor `createTestActions`

### DIFF
--- a/core-tests/test.hs
+++ b/core-tests/test.hs
@@ -67,7 +67,7 @@ getTestNames =
   foldTestTree
     trivialFold
       { foldSingle = \_ name _ -> [name]
-      , foldGroup = \_opts n l -> map ((n ++ ".") ++) l
+      , foldGroup = \_opts n l -> map ((n ++ ".") ++) (concat l)
       }
 
 -- the tree being tested

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,7 @@ Unreleased
 _YYYY-MM-DD_
 
 * Dependency loop error now lists all test cases that formed a cycle
+* `foldGroup` now takes `[b]` instead of `b` as its last argument to allow for custom fold strategies. This is a backwards incompatible change, but you can get the old behavior by applying `mconcat`.
 
 Version 1.4.3
 ---------------

--- a/core/Test/Tasty/Core.hs
+++ b/core/Test/Tasty/Core.hs
@@ -369,7 +369,7 @@ after deptype s =
 -- @since 0.7
 data TreeFold b = TreeFold
   { foldSingle :: forall t . IsTest t => OptionSet -> TestName -> t -> b
-  , foldGroup :: OptionSet -> TestName -> b -> b
+  , foldGroup :: OptionSet -> TestName -> [b] -> b
   -- ^ @since 1.4
   , foldResource :: forall a . OptionSet -> ResourceSpec a -> (IO a -> b) -> b
   , foldAfter :: OptionSet -> DependencyType -> Expr -> b -> b
@@ -392,7 +392,7 @@ data TreeFold b = TreeFold
 trivialFold :: Monoid b => TreeFold b
 trivialFold = TreeFold
   { foldSingle = \_ _ _ -> mempty
-  , foldGroup = \_ _ b -> b
+  , foldGroup = \_ _ bs -> mconcat bs
   , foldResource = \_ _ f -> f $ throwIO NotRunningTests
   , foldAfter = \_ _ _ b -> b
   }
@@ -429,7 +429,7 @@ foldTestTree (TreeFold fTest fGroup fResource fAfter) opts0 tree0 =
     go = \case
       AnnEmptyTestTree               -> mempty
       AnnSingleTest opts name test   -> fTest opts name test
-      AnnTestGroup opts name trees   -> fGroup opts name (foldMap go trees)
+      AnnTestGroup opts name trees   -> fGroup opts name (map go trees)
       AnnWithResource opts res0 tree -> fResource opts res0 $ \res -> go (tree res)
       AnnAfter opts deptype dep tree -> fAfter opts deptype dep (go tree)
 

--- a/core/Test/Tasty/Core.hs
+++ b/core/Test/Tasty/Core.hs
@@ -23,6 +23,7 @@ module Test.Tasty.Core
   , TreeFold(..)
   , trivialFold
   , foldTestTree
+  , foldTestTree0
   , treeOptions
   ) where
 
@@ -422,12 +423,27 @@ foldTestTree
   -> TestTree
      -- ^ the tree to fold
   -> b
-foldTestTree (TreeFold fTest fGroup fResource fAfter) opts0 tree0 =
+foldTestTree = foldTestTree0 mempty
+
+-- | Like 'foldTestTree', but with a custom (non-Monoid) empty value. Unlike
+-- 'foldTestTree', it is not part of the public API.
+foldTestTree0
+  :: forall b
+   . b
+     -- ^ "empty" value
+  -> TreeFold b
+     -- ^ the algebra (i.e. how to fold a tree)
+  -> OptionSet
+     -- ^ initial options
+  -> TestTree
+     -- ^ the tree to fold
+  -> b
+foldTestTree0 empty (TreeFold fTest fGroup fResource fAfter) opts0 tree0 =
   go (filterByPattern (evaluateOptions opts0 tree0))
   where
     go :: AnnTestTree OptionSet -> b
     go = \case
-      AnnEmptyTestTree               -> mempty
+      AnnEmptyTestTree               -> empty
       AnnSingleTest opts name test   -> fTest opts name test
       AnnTestGroup opts name trees   -> fGroup opts name (map go trees)
       AnnWithResource opts res0 tree -> fResource opts res0 $ \res -> go (tree res)

--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -158,12 +158,12 @@ buildTestOutput opts tree =
 
       return $ PrintTest name printTestName printTestResult
 
-    runGroup :: OptionSet -> TestName -> Ap (Reader Level) TestOutput -> Ap (Reader Level) TestOutput
+    runGroup :: OptionSet -> TestName -> [Ap (Reader Level) TestOutput] -> Ap (Reader Level) TestOutput
     runGroup _opts name grp = Ap $ do
       level <- ask
       let
         printHeading = printf "%s%s\n" (indent level) name
-        printBody = runReader (getApp grp) (level + 1)
+        printBody = runReader (getApp (mconcat grp)) (level + 1)
       return $ PrintHeading name printHeading printBody
 
   in
@@ -677,7 +677,7 @@ computeAlignment opts =
   foldTestTree
     trivialFold
       { foldSingle = \_ name _ level -> Maximum (stringWidth name + level)
-      , foldGroup = \_opts _ m -> m . (+ indentSize)
+      , foldGroup = \_opts _ m -> mconcat m . (+ indentSize)
       }
     opts
   where

--- a/core/Test/Tasty/Ingredients/ListTests.hs
+++ b/core/Test/Tasty/Ingredients/ListTests.hs
@@ -35,7 +35,7 @@ testsNames {- opts -} {- tree -} =
   foldTestTree
     trivialFold
       { foldSingle = \_opts name _test -> [name]
-      , foldGroup = \_opts groupName names -> map ((groupName ++ ".") ++) names
+      , foldGroup = \_opts groupName names -> map ((groupName ++ ".") ++) (concat names)
       }
 
 -- | The ingredient that provides the test listing functionality.

--- a/core/Test/Tasty/Run.hs
+++ b/core/Test/Tasty/Run.hs
@@ -236,7 +236,7 @@ type Tr = Traversal
 -- | Exceptions related to dependencies between tests.
 --
 -- @since 1.2
-data DependencyException
+newtype DependencyException
   = DependencyLoop [[Path]]
     -- ^ Test dependencies form cycles. In other words, test A cannot start
     -- until test B finishes, and test B cannot start until test

--- a/core/Test/Tasty/Run.hs
+++ b/core/Test/Tasty/Run.hs
@@ -1,7 +1,7 @@
 -- | Running tests
 {-# LANGUAGE ScopedTypeVariables, ExistentialQuantification, RankNTypes,
-             FlexibleContexts, BangPatterns, CPP, DeriveDataTypeable,
-             LambdaCase #-}
+             FlexibleContexts, CPP, DeriveDataTypeable, LambdaCase,
+             ViewPatterns #-}
 module Test.Tasty.Run
   ( Status(..)
   , StatusMap
@@ -271,7 +271,7 @@ createTestActions opts0 tree = do
         (trivialFold :: TreeFold Tr)
           { foldSingle = runSingleTest
           , foldResource = addInitAndRelease
-          , foldGroup = \_opts name (Traversal a) ->
+          , foldGroup = \_opts name (mconcat -> Traversal a) ->
               Traversal $ mapWriterT (local (first (Seq.|> name))) a
           , foldAfter = \_opts deptype pat (Traversal a) ->
               Traversal $ mapWriterT (local (second ((deptype, pat) :))) a


### PR DESCRIPTION
The refactor breaks the fold up in to two stages:

  * Building a test tree with initializers, finalizers, and actions with
    meta information: test path, test dependencies, and test status.

  * Collecting initializers and finalizers in a single pass, and
    applying them to every test action.

This removes an accidental quadratic complexity in favor of a linear
one caused by continuously mapping over tests while building that
list of tests. This removes the need for one layer in `Tr`'s monad
stack: `WriterT`. At the same time, it uses dedicated data structures
instead of tuples for ease of reading.

This commit aims to make future extensions easier.

----------------

Note that we need:

[Expose children in foldGroup](https://github.com/UnkindPartition/tasty/commit/7126701c61d6b2d8f5601e0873df92895589e4d2)

In order to build `TGroup`. The refactor alone doesn't warrant this API change of course, it is mainly used in https://github.com/UnkindPartition/tasty/pull/343.