### PR TITLE
Print unparsed options

### DIFF
--- a/core/Test/Tasty/Options.hs
+++ b/core/Test/Tasty/Options.hs
@@ -194,9 +194,14 @@ mkOptionCLParser mod =
     <> mod
     )
   where
+    name :: String
     name = untag (optionName :: Tagged v String)
-    parse = str >>=
-      maybe (readerError $ "Could not parse " ++ name) pure <$> parseValue
+
+    parse :: ReadM v
+    parse = do
+      s <- str
+      let err = "Could not parse: " ++ s ++ " is not a valid " ++ name
+      maybe (readerError err) pure (parseValue s)
 
 -- | Safe read function. Defined here for convenience to use for
 -- 'parseValue'.


### PR DESCRIPTION
When using `cabal test --test-options=...` it is sometimes non-trivial to figure out escaping rules applied, especially for options like `--pattern` which involve quotes, slashes, tildes and dollars.

Before this change:

  > option -p: Could not parse pattern

After:

  > option -p: Could not parse: //foo/ is not a valid pattern