### PR TITLE
CI: disable haddocks for GHC 8.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
         core-tests/resource-release-test.sh
 
     - name: Haddock
-      if: matrix.ghc != '8.0'
+      if: matrix.ghc != '8.0' && matrix.ghc != '8.2'
       run: cabal haddock all
 
   build-wasi:


### PR DESCRIPTION
The last release of `optparse-applicative` brought `text` into dependencies, and now it chokes Haddock with GHC 8.2: https://github.com/UnkindPartition/tasty/actions/runs/5147520656/jobs/9268225724. Cf. https://github.com/haskell/text/pull/478. 

I honestly see little value in indulging obsolete versions of Haddock, so I suggest just removing this build step from CI job for GHC 8.2.

