### PR TITLE
Don't depend on unbounded-delays for riscv64

### DIFF
--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -68,7 +68,7 @@ library
     ansi-terminal        >= 0.9  && < 1.2
 
   -- No reason to depend on unbounded-delays on 64-bit architecture
-  if(!arch(x86_64) && !arch(aarch64) && !arch(ppc64) && !arch(s390x))
+  if(!arch(x86_64) && !arch(aarch64) && !arch(ppc64) && !arch(s390x) && !arch(riscv64))
     build-depends:
       unbounded-delays >= 0.1 && < 0.2
 


### PR DESCRIPTION
64-bit RISC-V should fall into the same case in
https://github.com/UnkindPartition/tasty/pull/344 and should be added here. Tested locally.