### PR TITLE
CI: bump ghc-wasm-meta

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
   build-wasi:
     runs-on: ubuntu-latest
     env:
-      GHC_WASM_META_REV: 5ad5e045f52609eab12c7e09ed9b110980807957
+      GHC_WASM_META_REV: bd9533e34df53694a4c7e4102fced1fdc0596024
       FLAVOUR: '9.6'
     steps:
     - name: setup-ghc-wasm32-wasi


### PR DESCRIPTION
See https://github.com/UnkindPartition/tasty/pull/371#issuecomment-1605688537

The bindists used via ghc-wasm-meta are currently ephemeral. To fix this, we bump ghc-wasm-meta to get bindists which won't expire at least for another ~6 weeks. This will be fixed properly once https://gitlab.haskell.org/ghc/ghc-wasm-meta/-/merge_requests/29 gets merged, after which ghc-wasm-meta will have to be bumped again, but then for good.