### PR TITLE
Propagate 'forceMatch' for empty test groups

### DIFF
--- a/core-tests/SequentialTestGroup.hs
+++ b/core-tests/SequentialTestGroup.hs
@@ -89,6 +89,7 @@ filterTestTree pattern =
       , sequentialTestGroup "E" AllSucceed
         [ emptyTest "F"
         , emptyTest "G"
+        , testGroup "XX" []
         , emptyTest "H"
         ]
     ]

--- a/core/Test/Tasty/Core.hs
+++ b/core/Test/Tasty/Core.hs
@@ -563,6 +563,9 @@ filterByPattern = snd . go (Any False)
         | otherwise 
         -> (Any False, AnnEmptyTestTree)
 
+      AnnTestGroup (opts, _) name [] ->
+        (forceMatch, AnnTestGroup opts name [])
+
       AnnTestGroup (opts, _) name trees ->
         case lookupOption opts of
           Parallel ->


### PR DESCRIPTION
Similar to the logic in `goSeqGroup`:

https://github.com/UnkindPartition/tasty/blob/804b2a7d8323902ece3f1077c36860929343d9db/core/Test/Tasty/Run.hs#L442-L444

`filterByPattern` needs to return `forceMatch`, lest the return value will always be `Any False` due to `(mempty :: Any) ~ Any False` for the `Parallel` branch:

https://github.com/UnkindPartition/tasty/blob/804b2a7d8323902ece3f1077c36860929343d9db/core/Test/Tasty/Core.hs#L568-L572

Note that this only applies to `testGroup` (i.e. `Parallel`), but fixing it in that specific branch would create yet another level of nesting in `filterByPattern`.

An empty test group has been added to the `filterTestTree` test logic in `SequentialTestGroup` to prevent regressions.