### PR TITLE
Allow --pattern|-p option to repeat

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,7 @@ jobs:
         core-tests/exit-status-tests.sh
         # Prevent Git for Windows from replacing slashes with backslashes in patterns
         MSYS_NO_PATHCONV=1 core-tests/failing-pattern-test.sh
+        core-tests/multiple-pattern-test.sh
 
     - name: Test resource-release-test.sh
       if: runner.os != 'Windows'

--- a/core-tests/core-tests.cabal
+++ b/core-tests/core-tests.cabal
@@ -50,3 +50,9 @@ executable failing-pattern-test
   build-depends:       base <= 5, tasty, tasty-hunit, random >= 1.2, mtl
   default-extensions:  ScopedTypeVariables
   ghc-options:         -Wall -fno-warn-type-defaults
+
+executable multiple-pattern-test
+  import:              commons
+  main-is:             multiple-pattern-test.hs
+  build-depends:       base < 5, tasty, tasty-hunit
+  ghc-options:         -Wall -fno-warn-type-defaults

--- a/core-tests/multiple-pattern-test.hs
+++ b/core-tests/multiple-pattern-test.hs
@@ -1,0 +1,14 @@
+import Test.Tasty
+import Test.Tasty.HUnit
+
+main :: IO ()
+main = defaultMain $ testGroup "all"
+  [ testGroup "red"
+    [ testCase "square" $ pure ()
+    , testCase "circle" $ pure ()
+    ]
+  , testGroup "green"
+    [ testCase "square" $ pure ()
+    , testCase "circle" $ pure ()
+    ]
+  ]

--- a/core-tests/multiple-pattern-test.sh
+++ b/core-tests/multiple-pattern-test.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -eux
+
+if ! command -v multiple-pattern-test
+then
+  echo "multiple-pattern-test executable is not in PATH, aborting"
+  exit 1
+fi
+
+[ "$(multiple-pattern-test -l | wc -l)" -eq 4 ]
+[ "$(multiple-pattern-test -l -p red | wc -l)" -eq 2 ]
+[ "$(multiple-pattern-test -l -p circle | wc -l)" -eq 2 ]
+[ "$(multiple-pattern-test -l -p red -p circle | wc -l)" -eq 1 ]
+[ "$(multiple-pattern-test -l -p red -p circle -p green | wc -l)" -eq 0 ]
+
+# Edge case: the empty pattern matches everything
+[ "$(multiple-pattern-test -l -p '' | wc -l)" -eq 4 ]
+[ "$(multiple-pattern-test -l -p '' -p '' | wc -l)" -eq 4 ]
+[ "$(multiple-pattern-test -l -p '' -p red | wc -l)" -eq 2 ]
+[ "$(multiple-pattern-test -l -p red -p '' | wc -l)" -eq 2 ]
+[ "$(multiple-pattern-test -l -p '' -p red -p '' | wc -l)" -eq 2 ]
+[ "$(multiple-pattern-test -l -p red -p '' -p circle | wc -l)" -eq 1 ]
+
+# Environment variable is entirely overridden by any command line options
+[ "$(TASTY_PATTERN=red.circle multiple-pattern-test -l | wc -l)" -eq 1 ]
+[ "$(TASTY_PATTERN=red.circle multiple-pattern-test -l -p square | wc -l)" -eq 2 ]
+[ "$(TASTY_PATTERN=red.circle multiple-pattern-test -l -p square -p green | wc -l)" -eq 1 ]

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -14,6 +14,7 @@ _YYYY-MM-DD_
 * `PrintTest` constructor now has an extra field used to report progress.
   Supply `const (pure ())` as this extra field value if you want to skip progress reporting.
 * Progress reporting is no longer ignored.
+* The `-p`/`--pattern` option can be specified multiple times; only tests that match all patterns are run.
 
 Version 1.4.3
 ---------------


### PR DESCRIPTION
The effect of multiple -p options is the same as &&-ing the expressions together, but allowing them to be specified in separate options makes scripting test commands simpler.

---

Motivation: I want to run tests with a small shell script such as the following:

```
#!/usr/bin/env bash
default_test_options=(...)
test-exe "${default_test_options[@]}" "$@"
```

If `default_test_options` contains a pattern filter like `-p ! /very-slow-test/`, then I'm currently unable to provide any options to the script to further focus on a set of interest. I would have to write some extra logic to the script to detect pattern filters and inject them into the default pattern filter, making the script much more complicated than I would like it to be.

Allowing multiple `-p` options to be provided to Tasty programs resolves the issue.