### PR TITLE
Add field to Result which allows storage of arbitrary data

### DIFF
--- a/core/Test/Tasty/Providers.hs
+++ b/core/Test/Tasty/Providers.hs
@@ -35,6 +35,7 @@ testPassed desc = Result
   , resultShortDescription = "OK"
   , resultTime = 0
   , resultDetailsPrinter = noResultDetails
+  , resultExtraData = []
   }
 
 -- | 'Result' of a failed test.
@@ -49,6 +50,7 @@ testFailed desc = Result
   , resultShortDescription = "FAIL"
   , resultTime = 0
   , resultDetailsPrinter = noResultDetails
+  , resultExtraData = []
   }
 
 -- | 'Result' of a failed test with custom details printer

--- a/core/Test/Tasty/Run.hs
+++ b/core/Test/Tasty/Run.hs
@@ -194,6 +194,7 @@ executeTest action statusVar timeoutOpt hideProgressOpt inits fins = mask $ \res
             , resultShortDescription = "TIMEOUT"
             , resultTime = fromIntegral t
             , resultDetailsPrinter = noResultDetails
+            , resultExtraData = []
             }
       -- If compiled with unbounded-delays then t' :: Integer, otherwise t' :: Int
       let t' = fromInteger (min (max 0 t) (toInteger (maxBound :: Int64)))
@@ -490,6 +491,7 @@ resolveDeps tests = maybeCheckCycles $ do
           , resultShortDescription = "SKIP"
           , resultTime = 0
           , resultDetailsPrinter = noResultDetails
+          , resultExtraData = []
           }
       }
   return (TestAction { testAction = action, .. }, (testPath, dep_paths))

--- a/core/Test/Tasty/Runners.hs
+++ b/core/Test/Tasty/Runners.hs
@@ -35,6 +35,8 @@ module Test.Tasty.Runners
     -- * Running tests
   , Status(..)
   , Result(..)
+  , attachExtraData
+  , lookupExtraData
   , Outcome(..)
   , FailureReason(..)
   , resultSuccessful


### PR DESCRIPTION
This is proposal to add field to `Result` which allows attaching arbitrary data to it. Change is relatively small so I think it's easier to create PR and discuss concrete code than try to describe and everyone would understand it differently.

This change mostly benefits `tasty-bench` & `tasty-papi` which currently sneak data in `resultDescription` field. But to me it seems generally useful.

Storage is implemented as list of `Dynamic`. I expect that number of elements would be small (0 or 1) so linear scan is acceptable. 