### PR TITLE
tasty-quickcheck now requires tasty >= 1.5

### DIFF
--- a/quickcheck/tasty-quickcheck.cabal
+++ b/quickcheck/tasty-quickcheck.cabal
@@ -29,7 +29,7 @@ library
   other-extensions:    GeneralizedNewtypeDeriving, DeriveDataTypeable
   build-depends:       base >= 4.8 && < 5,
                        tagged < 0.9,
-                       tasty >= 1.0.1 && < 1.6,
+                       tasty >= 1.5 && < 1.6,
                        random < 1.3,
                        QuickCheck >= 2.10 && < 2.15,
                        optparse-applicative < 0.19


### PR DESCRIPTION
As reported at https://github.com/UnkindPartition/tasty/pull/311#discussion_r1320720849.

I went ahead and made a revision to prevent disruption: https://hackage.haskell.org/package/tasty-quickcheck-0.10.3/revisions/