### PR TITLE
Teach the HUnit Steps provider to log progress

### DIFF
--- a/hunit/CHANGELOG.md
+++ b/hunit/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Unreleased
+--------------
+
+* Teach `testCaseSteps` to log progress
+  ([#387](https://github.com/UnkindPartition/tasty/pull/387)).
+
 Version 0.10.1
 ---------------
 

--- a/hunit/Test/Tasty/HUnit/Steps.hs
+++ b/hunit/Test/Tasty/HUnit/Steps.hs
@@ -16,13 +16,18 @@ newtype TestCaseSteps = TestCaseSteps ((String -> IO ()) -> Assertion)
   deriving Typeable
 
 instance IsTest TestCaseSteps where
-  run _ (TestCaseSteps assertionFn) _ = do
+  run _ (TestCaseSteps assertionFn) yieldProgress = do
     ref <- newIORef []
 
     let
       stepFn :: String -> IO ()
       stepFn msg = do
         tme <- getTime
+        -- The number of steps is not fixed, so we can't 
+        -- provide the progress percentage.
+        -- We also don't provide the timings here, only
+        -- at the end.
+        yieldProgress (Progress msg 0)
         atomicModifyIORef ref (\l -> ((tme,msg):l, ()))
 
     hunitResult <- (Right <$> assertionFn stepFn) `catch`


### PR DESCRIPTION
A cheap improvement to also show the steps as the tests are running. This does mean that we need to bump the `tasty` lower bound to 1.5.