### PR TITLE
Two IntMap-related improvements

### DIFF
--- a/core/Test/Tasty/Run.hs
+++ b/core/Test/Tasty/Run.hs
@@ -9,7 +9,7 @@ module Test.Tasty.Run
   , DependencyException(..)
   ) where
 
-import qualified Data.IntMap as IntMap
+import qualified Data.IntMap.Strict as IntMap
 import qualified Data.Sequence as Seq
 import qualified Data.Foldable as F
 import Data.Int (Int64)
@@ -607,7 +607,7 @@ launchTestTree opts tree k0 = do
   let NumThreads numTheads = lookupOption opts
   (t,k1) <- timed $ do
      abortTests <- runInParallel numTheads (testAction <$> testActions)
-     (do let smap = IntMap.fromList $ zip [0..] (testStatus <$> testActions)
+     (do let smap = IntMap.fromDistinctAscList $ zip [0..] (testStatus <$> testActions)
          k0 smap)
       `finallyRestore` \restore -> do
          -- Tell all running tests to wrap up.

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -61,7 +61,7 @@ library
   build-depends:
     base                 >= 4.9  && < 5,
     stm                  >= 2.3  && < 2.6,
-    containers                      < 0.7,
+    containers           >= 0.5.8 && < 0.7,
     transformers         >= 0.5  && < 0.7,
     tagged               >= 0.5  && < 0.9,
     optparse-applicative >= 0.14 && < 0.19,


### PR DESCRIPTION
* `launchTestTree`: use `IntMap` strict in values

  At the moment we use `Data.IntMap` which is lazy in values, and we initialise values with thunks `testStatus <$> testActions`. This is outright silly: `testStatus` is just a selector for `TVar` field, forcing it to WHNF can do no harm.

  We also take an opportunity to replace `IntMap.fromList` with `IntMap.fromDistinctAscList`.

* `statusMapResult`: use `IntSet` instead of `IntMap ()`

  It seems the only reason behind `IntMap ()` was the absense of `Data.IntMap.withoutKeys`, which was only added in `containers-0.5.8`.

CC @martijnbastiaan for review