### PR TITLE
Use simpler ‘\r’ instead of cursor manipulation escape sequences

### DIFF
--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -152,8 +152,6 @@ buildTestOutput opts tree =
           name
           (replicate postNamePadding ' ')
 
-        resultPosition = length testNamePadded
-
         printTestName = do
           putStr testNamePadded
           hFlush stdout
@@ -171,11 +169,12 @@ buildTestOutput opts tree =
                         ("",  pct) -> printf "%.0f%% " pct
                         (txt, 0.0) -> printf "%s" txt
                         (txt, pct) -> printf "%s: %.0f%% " txt pct
-              setCursorColumn resultPosition
-              infoOk msg
+              putChar '\r'
               -- A new progress message may be shorter than the previous one
-              -- so we must clean until the end of the line
-              clearFromCursorToLineEnd
+              -- so we must clean whole line and print anew.
+              clearLine
+              putStr testNamePadded
+              infoOk msg
               hFlush stdout
 
         printTestResult result = do
@@ -191,8 +190,9 @@ buildTestOutput opts tree =
             time = resultTime result
 
           when getAnsiTricks $ do
-            setCursorColumn resultPosition
-            clearFromCursorToLineEnd
+            putChar '\r'
+            clearLine
+            putStr testNamePadded
 
           printFn (resultShortDescription result)
           when (floor (time * 1e6) >= minDurationMicros) $

--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -169,10 +169,9 @@ buildTestOutput opts tree =
                         ("",  pct) -> printf "%.0f%% " pct
                         (txt, 0.0) -> printf "%s" txt
                         (txt, pct) -> printf "%s: %.0f%% " txt pct
-              putChar '\r'
               -- A new progress message may be shorter than the previous one
               -- so we must clean whole line and print anew.
-              clearLine
+              putChar '\r'
               putStr testNamePadded
               infoOk msg
               hFlush stdout
@@ -191,7 +190,6 @@ buildTestOutput opts tree =
 
           when getAnsiTricks $ do
             putChar '\r'
-            clearLine
             putStr testNamePadded
 
           printFn (resultShortDescription result)


### PR DESCRIPTION
This primarily benefits displaying progress in Emacs’s shell-mode since it supports \r but doesn’t support ansi escapes other than color manipulation ones.

Checked that it works on Linux and Windows in msys, cygwin and cmd.exe (the last one doesn't display colors correctly though but cursor manipulation is OK).