### PR TITLE
Avoid blanket import from `GHC.Conc`

### DIFF
--- a/core/Control/Concurrent/Async.hs
+++ b/core/Control/Concurrent/Async.hs
@@ -48,7 +48,7 @@ import Control.Concurrent
 import Control.Monad
 import Data.IORef
 import Data.Typeable
-import GHC.Conc
+import GHC.Conc (ThreadId(..))
 import GHC.Exts
 import GHC.IO hiding (onException)
 


### PR DESCRIPTION
Corresponding ticket for `async` itself at https://github.com/simonmar/async/pull/153.