### PR TITLE
Mention the proper env vars for usage in MinGW

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,9 +820,12 @@ Use `sequentialTestGroup` to mitigate these problems.
 
 3. **Q**: Patterns with slashes do not work on Windows. How can I fix it?
 
-   **A**: If you are running Git for Windows terminal, it has a habit of converting slashes
-   to backslashes. Set `MSYS_NO_PATHCONV=1` to prevent this behaviour, or follow other
-   suggestions from [Known Issues](https://github.com/git-for-windows/build-extra/blob/main/ReleaseNotes.md#known-issues).
+   **A**: If you are running Git for Windows terminal, it has a habit of
+   converting slashes to backslashes. Set `MSYS_NO_PATHCONV=1` when running the
+   Git for Windows terminal and `MSYS2_ARG_CONV_EXCL=*` when running a MinGW
+   bash directly to prevent this behaviour, or follow other suggestions from
+   [Known
+   Issues](https://github.com/git-for-windows/build-extra/blob/main/ReleaseNotes.md#known-issues).
 
 ## Press
 

--- a/core/Test/Tasty/Patterns.hs
+++ b/core/Test/Tasty/Patterns.hs
@@ -48,7 +48,15 @@ instance IsOption TestPattern where
   defaultValue = noPattern
   parseValue = parseTestPattern
   optionName = return "pattern"
-  optionHelp = return "Select only tests which satisfy a pattern or awk expression"
+#if !defined(mingw32_HOST_OS)
+  optionHelp = return "Select only tests which satisfy a pattern or awk expression."
+#else
+  optionHelp = return
+    $ unwords [ "Select only tests which satisfy a pattern or awk expression."
+              , "Consider using `MSYS_NO_PATHCONV=1` or `MSYS2_ARG_CONV_EXCL=*`"
+              , "to prevent pattern mangling."
+              ]
+#endif
   optionCLParser =
     fmap (TestPattern . fmap (foldr1 And) . nonEmpty . catMaybes . coerce @[TestPattern]) . some $
       mkOptionCLParser (short 'p' <> metavar "PATTERN")


### PR DESCRIPTION
If one doesn't set that flag, by default any argument `/.../` gets converted to a path by MSYS2 ([see](https://www.msys2.org/docs/filesystem-paths/)). 

```
❯ cabal run my-testsuite -- -p "/my pattern/"
option -p: Could not parse: C:/msys64/my pattern/ is not a valid pattern
...
❯ MSYS2_ARG_CONV_EXCL=* cabal run my-testsuite -- -p "/my pattern/"
<it works>
```


This will print the following advise on failing tests when running on what looks like a MinGW enviroment:

```
          Use -p '/my pattern/' to rerun this test only.
          If running in a MinGW shell, set the environment variable 'MSYS2_ARG_CONV_EXCL=*' or the pattern above will be mangled.
```

It still uses the "If" formulation because PowerShell running the mingw haskell toolchain won't need this parameter (modulo haskell/cabal#9519):

```
PS C:\Users\Javier\example> cabal run my-testsuite -- -p "/my pattern/"
<works>
```