### PR TITLE
Allow ansi-terminal-1.1; CI bumps&clean

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,3 @@
-# Mostly copied from the haskell/bytestring repo
 name: ci
 
 on:
@@ -18,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-22.04]
-        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0', '9.2', '9.4', '9.6']
+        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0', '9.2', '9.4', '9.6', '9.8']
         include:
         - os: macOS-latest
           ghc: 'latest'
@@ -27,35 +26,29 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install prerequisites for GHC <= 8.2 on ubuntu-22.04
       if: runner.os == 'Linux' && matrix.ghc <= '8.2'
       run: |
         sudo apt-get install libncurses5 libtinfo5
 
-    - uses: haskell/actions/setup@v2
-      id: setup-haskell-cabal
+    - uses: haskell-actions/setup@v2
+      id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
+        cabal-update: true
 
-    - name: Update cabal package database
-      run: cabal update
-
-    - name: Build plan
-      run: cabal freeze --enable-tests --enable-benchmarks
-
-    # Cache logic see https://github.com/haskell/actions/issues/7#issuecomment-745697160
-    - uses: actions/cache@v3
-      name: Cache cabal stuff
+    - uses: actions/cache/restore@v4
+      name: Restore cabal cache
+      id: cache
       with:
         path: |
-          ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+          ${{ steps.setup-haskell.outputs.cabal-store }}
           dist-newstyle
-        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}-$${ github.sha }
+        key: ${{ runner.os }}-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-commit-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}-
-          ${{ runner.os }}-${{ matrix.ghc }}-
+          ${{ runner.os }}-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-
 
     - name: Test
       run: |
@@ -63,7 +56,7 @@ jobs:
 
         cabal build all
         cabal install ./core-tests
-        export PATH=$HOME/.cabal/bin:$PATH
+        export PATH="${HOME}/.cabal/bin:${PATH}"
 
         (cd core-tests && tasty-core-tests +RTS -N2)
         core-tests/exit-status-tests.sh
@@ -74,12 +67,21 @@ jobs:
     - name: Test resource-release-test.sh
       if: runner.os != 'Windows'
       run: |
-        export PATH=$HOME/.cabal/bin:$PATH
+        export PATH="${HOME}/.cabal/bin:${PATH}"
         core-tests/resource-release-test.sh
 
     - name: Haddock
       if: matrix.ghc != '8.0' && matrix.ghc != '8.2' && matrix.ghc != '8.4'
       run: cabal haddock all
+
+    - name: Save cache
+      if: always()
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ${{ steps.setup-haskell.outputs.cabal-store }}
+          dist-newstyle
+        key: ${{ steps.cache.outputs.cache-primary-key }}
 
   build-wasi:
     runs-on: ubuntu-latest
@@ -87,15 +89,18 @@ jobs:
       GHC_WASM_META_REV: 895f7067e1d4c918a45559da9d2d6a403a690703
       FLAVOUR: '9.6'
     steps:
-    - name: setup-ghc-wasm32-wasi
+
+    - name: Setup ghc-wasm32-wasi
       run: |
-        cd $(mktemp -d)
-        curl -L https://gitlab.haskell.org/ghc/ghc-wasm-meta/-/archive/$GHC_WASM_META_REV/ghc-wasm-meta-master.tar.gz | tar xz --strip-components=1
+        cd "$(mktemp -d)"
+        curl -L "https://gitlab.haskell.org/ghc/ghc-wasm-meta/-/archive/${GHC_WASM_META_REV}/ghc-wasm-meta-master.tar.gz" | tar xz --strip-components=1
         ./setup.sh
         ~/.ghc-wasm/add_to_github_path.sh
-    - uses: actions/checkout@v3
 
-    - uses: actions/cache@v3
+    - uses: actions/checkout@v4
+
+    - uses: actions/cache/restore@v4
+      id: cache
       with:
         path: |
           ~/.ghc-wasm/.cabal/store
@@ -108,14 +113,14 @@ jobs:
       run: |
         wasm32-wasi-cabal build all
 
-        TEST_WRAPPERS=$(mktemp -d)
-        echo $TEST_WRAPPERS >> $GITHUB_PATH
+        TEST_WRAPPERS="$(mktemp -d)"
+        echo "${TEST_WRAPPERS}" >> "${GITHUB_PATH}"
         wasm32-wasi-cabal install ./core-tests
         for test in tasty-core-tests exit-status-test resource-release-test failing-pattern-test; do
-          echo '#!/usr/bin/env bash' > $TEST_WRAPPERS/$test
+          echo '#!/usr/bin/env bash' > "${TEST_WRAPPERS}/${test}"
           echo "wasmtime --mapdir /::/ --env PWD=\"\$PWD\" ~/.ghc-wasm/.cabal/bin/$test.wasm -- \"\$@\"" \
-            >> $TEST_WRAPPERS/$test
-          chmod +x $TEST_WRAPPERS/$test
+            >> "${TEST_WRAPPERS}/${test}"
+          chmod +x "${TEST_WRAPPERS}/${test}"
         done
 
     - name: Test
@@ -123,3 +128,11 @@ jobs:
         (cd core-tests && tasty-core-tests)
         core-tests/exit-status-tests.sh
         core-tests/failing-pattern-test.sh
+
+    - uses: actions/cache/save@v4
+      if: always()
+      with:
+        path: |
+          ~/.ghc-wasm/.cabal/store
+          dist-newstyle
+        key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -65,7 +65,7 @@ library
     transformers         >= 0.5  && < 0.7,
     tagged               >= 0.5  && < 0.9,
     optparse-applicative >= 0.14 && < 0.19,
-    ansi-terminal        >= 0.9  && < 1.1
+    ansi-terminal        >= 0.9  && < 1.2
 
   -- No reason to depend on unbounded-delays on 64-bit architecture
   if(!arch(x86_64) && !arch(aarch64))


### PR DESCRIPTION
- CI: include GHC 9.8, bump actions, separate cache restore/save
- Allow ansi-terminal-1.1 (published as revision 2: https://hackage.haskell.org/package/tasty-1.5/revisions/)
