### PR TITLE
Avoid running earlier successes with --quickcheck-replay

### DIFF
--- a/quickcheck/CHANGELOG.md
+++ b/quickcheck/CHANGELOG.md
@@ -4,6 +4,9 @@ Changes
 Next Version
 ------------
 
+Version 0.11
+--------------
+
 * Produce seeds that run a single failing tests instead of reproducing
   all the earlier successes ([#410](https://github.com/UnkindPartition/tasty/pull/410)).
 

--- a/quickcheck/CHANGELOG.md
+++ b/quickcheck/CHANGELOG.md
@@ -7,7 +7,7 @@ Next Version
 * Produce seeds that run a single failing tests instead of reproducing
   all the earlier successes ([#410](https://github.com/UnkindPartition/tasty/pull/410)).
 
-  Seeds are now strings, instead of single integers. e.g.
+  Seeds are now strings, instead of single integers, e.g.
   `--quickcheck-replay="(SMGen 2909028190965759779 12330386376379709109,0)"`
 
   Single integer seeds are still accepted as input, but they do run through

--- a/quickcheck/CHANGELOG.md
+++ b/quickcheck/CHANGELOG.md
@@ -1,6 +1,18 @@
 Changes
 =======
 
+Next Version
+------------
+
+* Produce seeds that run a single failing tests instead of reproducing
+  all the earlier successes ([#410](https://github.com/UnkindPartition/tasty/pull/410)).
+
+  Seeds are now strings, instead of single integers. e.g.
+  `--quickcheck-replay="(SMGen 2909028190965759779 12330386376379709109,0)"`
+
+  Single integer seeds are still accepted as input, but they do run through
+  earlier successes.
+
 Version 0.10.3
 --------------
 

--- a/quickcheck/CHANGELOG.md
+++ b/quickcheck/CHANGELOG.md
@@ -7,11 +7,16 @@ Next Version
 * Produce seeds that run a single failing tests instead of reproducing
   all the earlier successes ([#410](https://github.com/UnkindPartition/tasty/pull/410)).
 
-  Seeds are now strings, instead of single integers, e.g.
+  Seeds are now pairs instead of single integers, e.g.
   `--quickcheck-replay="(SMGen 2909028190965759779 12330386376379709109,0)"`
 
   Single integer seeds are still accepted as input, but they do run through
   earlier successes.
+
+  The `QuickCheckReplay` type used as a tasty option has three data constructors
+  now. `QuickCheckReplayNone` is the default value and provides no seed.
+  `QuickCheckReplayLegacy` takes an integer as before. The `QuickCheckReplay`
+  data constructor takes the new seed form.
 
 Version 0.10.3
 --------------

--- a/quickcheck/Test/Tasty/QuickCheck.hs
+++ b/quickcheck/Test/Tasty/QuickCheck.hs
@@ -85,11 +85,17 @@ newtype QuickCheckTests = QuickCheckTests Int
 -- | Replay seed
 data QuickCheckReplay
     = -- | No seed
+      --
+      -- @since 0.11
       QuickCheckReplayNone
     | -- | Legacy integer seed
+      --
+      -- @since 0.11
       QuickCheckReplayLegacy Int
     | -- | @(qcgen, intSize)@ holds both the seed and the size
       -- to run QuickCheck tests
+      --
+      -- @since 0.11
       QuickCheckReplay (QCGen, Int)
   deriving (Typeable)
 

--- a/quickcheck/Test/Tasty/QuickCheck.hs
+++ b/quickcheck/Test/Tasty/QuickCheck.hs
@@ -174,7 +174,7 @@ instance IsOption QuickCheckMaxShrinks where
 -- but may be used by others.
 --
 -- The returned Int is kept only for backward compatibility purposes. It
--- has no use in tast-quickcheck.
+-- has no use in @tasty-quickcheck@.
 --
 -- @since 0.9.1
 optionSetToArgs :: OptionSet -> IO (Int, QC.Args)

--- a/quickcheck/tasty-quickcheck.cabal
+++ b/quickcheck/tasty-quickcheck.cabal
@@ -55,6 +55,7 @@ test-suite test
     , tasty-quickcheck
     , tasty-hunit
     , pcre-light
+    , QuickCheck
   ghc-options: -Wall
   if (!impl(ghc >= 8.0) || os(windows))
     buildable: False

--- a/quickcheck/tasty-quickcheck.cabal
+++ b/quickcheck/tasty-quickcheck.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                tasty-quickcheck
-version:             0.10.3
+version:             0.11
 synopsis:            QuickCheck support for the Tasty test framework.
 description:         QuickCheck support for the Tasty test framework.
                      .

--- a/quickcheck/tests/test.hs
+++ b/quickcheck/tests/test.hs
@@ -133,7 +133,7 @@ runMaxSized sz p =
 runReplayWithSeed :: Testable p => (QCGen, Int) -> p -> IO Result
 runReplayWithSeed seedSz p =
   run
-    (singleOption $ QuickCheckReplay $ Just (Right seedSz))
+    (singleOption $ QuickCheckReplay seedSz)
     (QC $ property p)
     (const $ return ())
 


### PR DESCRIPTION
On failure, tasty-quickcheck now suggests string seeds (with an implementation-dependent structure). Integer seeds are still accepted as input though.

Fixes #383