### PR TITLE
Don't depend on unbounded-delays on s390x

### DIFF
--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -68,7 +68,7 @@ library
     ansi-terminal        >= 0.9  && < 1.2
 
   -- No reason to depend on unbounded-delays on 64-bit architecture
-  if(!arch(x86_64) && !arch(aarch64))
+  if(!arch(x86_64) && !arch(aarch64) && !arch(s390x))
     build-depends:
       unbounded-delays >= 0.1 && < 0.2
 


### PR DESCRIPTION
... which is a 64 bit architecture.

Note: s390x is big endian, but that hopefully doesn't matter.