### PR TITLE
Initial options

### DIFF
--- a/core/Test/Tasty.hs
+++ b/core/Test/Tasty.hs
@@ -36,7 +36,9 @@ module Test.Tasty
   , sequentialTestGroup
   -- * Running tests
   , defaultMain
+  , defaultMainWithOptions
   , defaultMainWithIngredients
+  , defaultMainWithIngredientsAndOptions
   , defaultIngredients
   , includingOptions
   -- * Adjusting and querying options
@@ -105,6 +107,12 @@ defaultIngredients = [listingTests, consoleTestReporter]
 -- @since 0.1
 defaultMain :: TestTree -> IO ()
 defaultMain = defaultMainWithIngredients defaultIngredients
+
+-- |
+--
+-- @since x.y
+defaultMainWithOptions :: OptionSet -> TestTree -> IO ()
+defaultMainWithOptions opts = defaultMainWithIngredientsAndOptions opts defaultIngredients
 
 -- | Locally adjust the option value for the given test subtree.
 --

--- a/core/Test/Tasty/Runners.hs
+++ b/core/Test/Tasty/Runners.hs
@@ -32,6 +32,7 @@ module Test.Tasty.Runners
   , optionParser
   , suiteOptionParser
   , defaultMainWithIngredients
+  , defaultMainWithIngredientsAndOptions
     -- * Running tests
   , Status(..)
   , Result(..)

--- a/quickcheck/Test/Tasty/QuickCheck.hs
+++ b/quickcheck/Test/Tasty/QuickCheck.hs
@@ -127,6 +127,7 @@ newtype QuickCheckTimeout = QuickCheckTimeout Timeout
 
 instance IsOption QuickCheckTests where
   defaultValue = 100
+  showDefaultValue (QuickCheckTests n) = Just (show n)
   parseValue =
     -- We allow numeric underscores for readability; see
     -- https://github.com/UnkindPartition/tasty/issues/263

--- a/quickcheck/tasty-quickcheck.cabal
+++ b/quickcheck/tasty-quickcheck.cabal
@@ -59,3 +59,19 @@ test-suite test
   ghc-options: -Wall
   if (!impl(ghc >= 8.0) || os(windows))
     buildable: False
+
+test-suite options-example
+  default-language:
+    Haskell2010
+  default-extensions: CPP
+  type:
+    exitcode-stdio-1.0
+  hs-source-dirs:
+    tests
+  main-is:
+    options-example.hs
+  build-depends:
+      base >= 4.7 && < 5
+    , tasty >= 1.5
+    , tasty-quickcheck
+  ghc-options: -Wall

--- a/quickcheck/tests/options-example.hs
+++ b/quickcheck/tests/options-example.hs
@@ -1,0 +1,15 @@
+module Main (main) where
+
+import Test.Tasty
+import Test.Tasty.Options
+import Test.Tasty.QuickCheck
+
+main :: IO ()
+main = defaultMainWithOptions opts $ testGroup "options-example"
+  [ testProperty "assoc" assoc_prop
+  ]
+  where
+    opts = singleOption (QuickCheckTests 1000)
+
+assoc_prop :: Int -> Int -> Int -> Property
+assoc_prop x y z = (x + y) + z === x + (y + z)


### PR DESCRIPTION
It turns out `tasty` very much had all building blocks to allow specifying initial option set.

This PR is a draft, I'd welcome if anyone takes over as I did the least possible as a proof-of-concept (no haddocks for example).

The `options-example` "test-suite" is a demo.

`cabal run options-example -- --help ` prints

```
  --quickcheck-tests NUMBER
                           Number of test cases for QuickCheck to generate.
                           Underscores accepted: e.g. 10_000_000 (default: 1000)
```

(I made default value visible).

and if you run test the output is

```
options-example
  assoc: OK
    +++ OK, passed 1000 tests.
```

so the value is actually used. But it can still be overridden with `--quickcheck-tests`: `cabal run options-example -- --quickcheck-tests 1234`

```
options-example
  assoc: OK
    +++ OK, passed 1234 tests.
```