### PR TITLE
Define showDefaultValue for QuickCheckTests, QuickCheckMaxSize and QuickCheckMaxRatio

### DIFF
--- a/quickcheck/CHANGELOG.md
+++ b/quickcheck/CHANGELOG.md
@@ -5,6 +5,7 @@ Version 0.11.1
 --------------
 
 * Add timeouts for individual tests within a property.
+* Define `showDefaultValue` for `QuickCheckTests`, `QuickCheckMaxSize` and `QuickCheckMaxRatio`.
 
 Version 0.11
 --------------

--- a/quickcheck/Test/Tasty/QuickCheck.hs
+++ b/quickcheck/Test/Tasty/QuickCheck.hs
@@ -127,6 +127,7 @@ newtype QuickCheckTimeout = QuickCheckTimeout Timeout
 
 instance IsOption QuickCheckTests where
   defaultValue = 100
+  showDefaultValue (QuickCheckTests n) = Just (show n)
   parseValue =
     -- We allow numeric underscores for readability; see
     -- https://github.com/UnkindPartition/tasty/issues/263
@@ -156,6 +157,7 @@ defaultMaxSize = QC.maxSize QC.stdArgs
 
 instance IsOption QuickCheckMaxSize where
   defaultValue = fromIntegral defaultMaxSize
+  showDefaultValue (QuickCheckMaxSize n) = Just (show n)
   parseValue = fmap QuickCheckMaxSize . safeRead
   optionName = return "quickcheck-max-size"
   optionHelp = return "Size of the biggest test cases quickcheck generates"
@@ -163,6 +165,7 @@ instance IsOption QuickCheckMaxSize where
 
 instance IsOption QuickCheckMaxRatio where
   defaultValue = fromIntegral $ QC.maxDiscardRatio QC.stdArgs
+  showDefaultValue (QuickCheckMaxRatio n) = Just (show n)
   parseValue = fmap QuickCheckMaxRatio . safeRead
   optionName = return "quickcheck-max-ratio"
   optionHelp = return "Maximum number of discared tests per successful test before giving up"


### PR DESCRIPTION
Taking inspiration from #427, let's define `showDefaultValue` for `QuickCheckTests`, `QuickCheckMaxSize` and `QuickCheckMaxRatio`.

Note that `showDefaultValue` for `QuickCheckMaxShrinks` is consciously omitted, because it is equal to `maxBound :: Int`, which looks too puzzling in `--help`.

Before:
```
Available options:
  ...
  --quickcheck-tests NUMBER
                           Number of test cases for QuickCheck to generate.
                           Underscores accepted: e.g. 10_000_000
  --quickcheck-replay SEED Random seed to use for replaying a previous test run
  --quickcheck-show-replay Show a replay token for replaying tests
  --quickcheck-max-size NUMBER
                           Size of the biggest test cases quickcheck generates
  --quickcheck-max-ratio NUMBER
                           Maximum number of discared tests per successful test
                           before giving up
  --quickcheck-verbose     Show the generated test cases
  --quickcheck-shrinks NUMBER
                           Number of shrinks allowed before QuickCheck will fail
                           a test
```

After:

```
Available options:
  ...
  --quickcheck-tests NUMBER
                           Number of test cases for QuickCheck to generate.
                           Underscores accepted: e.g. 10_000_000 (default: 100)
  --quickcheck-replay SEED Random seed to use for replaying a previous test run
  --quickcheck-show-replay Show a replay token for replaying tests
  --quickcheck-max-size NUMBER
                           Size of the biggest test cases quickcheck generates
                           (default: 100)
  --quickcheck-max-ratio NUMBER
                           Maximum number of discared tests per successful test
                           before giving up (default: 10)
  --quickcheck-verbose     Show the generated test cases
  --quickcheck-shrinks NUMBER
                           Number of shrinks allowed before QuickCheck will fail
                           a test
  --quickcheck-timeout DURATION
                           Timeout for individual tests within a QuickCheck
                           property (suffixes: ms,s,m,h; default: s)
```