### PR TITLE
Add option for printing the number of QuickCheck tests and shrinks

### DIFF
--- a/quickcheck/Test/Tasty/QuickCheck.hs
+++ b/quickcheck/Test/Tasty/QuickCheck.hs
@@ -283,8 +283,21 @@ quickCheck yieldProgress args
   = (.) (QC.quickCheckWithResult args)
   $ QCP.callback
   $ QCP.PostTest QCP.NotCounterexample
-  $ \QC.MkState {QC.maxSuccessTests, QC.numSuccessTests} _ ->
-    yieldProgress $ emptyProgress {progressPercent = fromIntegral numSuccessTests / fromIntegral maxSuccessTests}
+  $ \st@QC.MkState {QC.maxSuccessTests, QC.numSuccessTests} _ ->
+    yieldProgress $
+      if QC.numTotTryShrinks st > 0 then
+        emptyProgress {
+            progressText = showShrinkCount st
+          }
+      else
+        emptyProgress {
+            progressPercent = fromIntegral numSuccessTests / fromIntegral maxSuccessTests
+          }
+
+-- Based on 'QuickCheck.Test.failureSummaryAndReason'.
+showShrinkCount :: QC.State -> String
+showShrinkCount st = show (QC.numSuccessShrinks st) ++ " shrink" ++ plural
+  where plural = if QC.numSuccessShrinks st == 1 then "" else "s"
 
 successful :: QC.Result -> Bool
 successful r =

--- a/quickcheck/tests/test.hs
+++ b/quickcheck/tests/test.hs
@@ -110,8 +110,11 @@ main =
           resultDescription =~ "Use .* to reproduce"
 
       -- Run the test suite manually and check that progress does not go beyond 100%
-      , testProperty "Percent Complete" $ withMaxSuccess 1000 $ \(_ :: Int) -> ioProperty $ threadDelay 10000
-
+      , testProperty "Percent Complete"  $
+          withMaxSuccess 1000 $ \(_ :: Int) -> ioProperty $ threadDelay 10000
+      , testProperty "Number of shrinks" $
+          expectFailure $ withMaxSize 1000 $ \(Large (x :: Int)) ->
+            ioProperty $ threadDelay 100000 >> pure (x <= 100)
       ]
 
 run' :: Testable p => p -> IO Result


### PR DESCRIPTION
Currently, `tasty` and `tasty-quickcheck` will print a progress percentage, so one can see test progression. However, once a property finds a failure and starts shrinking, then test progression stops. Importantly, it is not clear how the shrinker is progressing, though it would be useful information to show, e.g., to judge whether a test is shrinking too slow, whether the shrinker loops, or whether a shrunk test case hangs. This commit adds a new option to enable printing the number of QuickCheck tests (and shrinks on test failure) in addition to the percentage.

I know this feature has been suggested before here: https://github.com/UnkindPartition/tasty/pull/419#discussion_r1632346098). In my opinion it would be a generally useful feature to include, and it's optional so that it does not use up too much UI space by default. Let me know what you think!