### PR TITLE
Release tasty-1.5.2

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,6 +1,19 @@
 Changes
 =======
 
+Version 1.5.2
+--------------
+
+_2024-11-03_
+
+* Partially revert [#393](https://github.com/UnkindPartition/tasty/pull/393)
+  to fix progress reporting outside of Emacs.
+* Do not depend on `unbounded-delays` on `ppc64`, `s390x` and `riscv64`
+  ([#371](https://github.com/UnkindPartition/tasty/pull/371),
+   [#422](https://github.com/UnkindPartition/tasty/pull/422),
+   [#423](https://github.com/UnkindPartition/tasty/pull/423)).
+
+
 Version 1.5.1
 --------------
 

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                tasty
-version:             1.5.1
+version:             1.5.2
 synopsis:            Modern and extensible testing framework
 description:         Tasty is a modern testing framework for Haskell.
                      It lets you combine your unit tests, golden


### PR DESCRIPTION
`tasty-1.5.1` got deprecated because of an issue with progress reporting, so we need to make a release, which includes d2a0562e6dc5a825cfdb642e3bc289861340ba4e.