### PR TITLE
Add line wrap disablement to ConsoleReporter

### DIFF
--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -232,7 +232,7 @@ buildTestOutput opts tree =
     withoutLineWrap :: IO () -> IO ()
 #if MIN_VERSION_ansi_terminal(1,1,2)
     withoutLineWrap m | getAnsiTricks =
-      bracket disableLineWrap (\_ -> enableLineWrap) (\_ -> m)
+      bracket_ disableLineWrap enableLineWrap m
 #endif
     withoutLineWrap m = m
 


### PR DESCRIPTION
I don't propose changing cabal.project, this is just for a demo until the PR to ansi-terminal is merged (https://github.com/UnkindPartition/ansi-terminal/pull/171/)

I saw that our test suite leaves garbage in the terminal output despite using `--hide-successes`. This turns out to be worse the narrower my terminal is. The more general problem is that `ConsoleReporter` leaves garbage in the terminal when the lines it prints are wrapped, because it doesn't know to clear multiple lines, just the most recent one. This PR fixes that by disabling line wrapping while printing that line.

This PR makes `ConsoleReporter`'s ANSI tricks clean up after themselves properly in the presence of a narrow terminal, a long test name, or a long progress message, including those printed by `testCaseWithSteps` from tasty-hunit. It also prevents test group names from wrapping, because that has the same cause.