### PR TITLE
Tests: switch from pcre-light to regex-tdfa

### DIFF
--- a/quickcheck/tasty-quickcheck.cabal
+++ b/quickcheck/tasty-quickcheck.cabal
@@ -51,10 +51,10 @@ test-suite test
     test.hs
   build-depends:
       base >= 4.7 && < 5
+    , regex-tdfa >= 1.3 && < 1.4
     , tasty >= 1.5
     , tasty-quickcheck
     , tasty-hunit
-    , pcre-light
     , QuickCheck
   ghc-options: -Wall
   if (!impl(ghc >= 8.0) || os(windows))

--- a/quickcheck/tests/test.hs
+++ b/quickcheck/tests/test.hs
@@ -7,10 +7,9 @@ import Test.Tasty.Providers as Tasty
 import Test.Tasty.Runners as Tasty
 import Test.Tasty.QuickCheck
 import Test.Tasty.HUnit
-import Data.Maybe
 import Test.QuickCheck.Random (QCGen)
-import Text.Regex.PCRE.Light.Char8
 import Text.Printf
+import qualified Text.Regex.TDFA as Regex
 
 (=~), (!~)
   :: String -- ^ text
@@ -21,20 +20,11 @@ text =~ regexStr =
     msg = printf "Expected /%s/, got %s" regexStr (show text)
     -- NB show above the intentional -- to add quotes around the string and
     -- escape newlines etc.
-  in assertBool msg $ match' text regexStr
+  in assertBool msg $ text Regex.=~ regexStr
 text !~ regexStr =
   let
     msg = printf "Did not expect /%s/, got %s" regexStr (show text)
-  in assertBool msg $ not $ match' text regexStr
-
--- note: the order of arguments is reversed relative to match from
--- pcre-light, but consistent with =~ and !~
-match' :: String -> String -> Bool
-match' text regexStr =
-  let
-    regex = compile regexStr []
-  in
-    isJust $ match regex text []
+  in assertBool msg $ not $ text Regex.=~ regexStr
 
 main :: IO ()
 main =


### PR DESCRIPTION
`pcre-light` is not that light, because on a clean machine it fails with
```
Base.hsc:105:10: fatal error: 'pcre.h' file not found
#include <pcre.h>
         ^~~~~~~~
1 error generated.
```

There is no point to complicate build requirements, we can just use `regex-tdfa` instead.