### PR TITLE
ConsoleReporter: force flushing of stdout after showCursor

### DIFF
--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -563,7 +563,9 @@ consoleTestReporterWithHook hook = TestReporter consoleTestReporterOptions $
       isTermColor <- hSupportsANSIColor stdout
 
       (\k -> if isTerm
-        then (do hideCursor; k) `finally` showCursor
+        -- When killing with Ctrl+C 'showCursor' can fail
+        -- to restore terminal cursor if not flushed explicitly
+        then (do hideCursor; k) `finally` (do showCursor; hFlush stdout)
         else k) $ do
 
           hSetBuffering stdout LineBuffering


### PR DESCRIPTION
I don't think I can write a test for this, but I have a persistent problem with some massive test suites when killing application with Ctrl+C leaves a terminal cursor hidden. I verified manually that flushing stdout fixes the issue.