### PR TITLE
Allow containers-0.8

### DIFF
--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -61,7 +61,7 @@ library
   build-depends:
     base                 >= 4.9  && < 5,
     stm                  >= 2.3  && < 2.6,
-    containers           >= 0.5.8 && < 0.8,
+    containers           >= 0.5.8 && < 0.9,
     transformers         >= 0.5  && < 0.7,
     tagged               >= 0.5  && < 0.9,
     optparse-applicative >= 0.14 && < 0.19,

--- a/hunit/Test/Tasty/HUnit/Steps.hs
+++ b/hunit/Test/Tasty/HUnit/Steps.hs
@@ -4,9 +4,9 @@ module Test.Tasty.HUnit.Steps (testCaseSteps) where
 import Control.Applicative
 import Control.Exception
 import Data.IORef
-import Data.List (foldl')
+import Data.Foldable
 import Data.Typeable (Typeable)
-import Prelude  -- Silence AMP import warnings
+import Prelude hiding (Foldable(..))
 import Test.Tasty.HUnit.Orig
 import Test.Tasty.Providers
 import Test.Tasty.Runners (getTime)


### PR DESCRIPTION
Tested with
```sh
cabal build all --enable-tests --enable-benchmarks -c 'containers>=0.8' --allow-newer='regex-tdfa:containers,regex-base:containers'
```