### PR TITLE
Add filterable sequential test groups

### DIFF
--- a/core/Test/Tasty.hs
+++ b/core/Test/Tasty.hs
@@ -34,6 +34,7 @@ module Test.Tasty
   , TestTree
   , testGroup
   , sequentialTestGroup
+  , filterableSequentialTestGroup
   -- * Running tests
   , defaultMain
   , defaultMainWithIngredients

--- a/core/Test/Tasty/Run.hs
+++ b/core/Test/Tasty/Run.hs
@@ -421,8 +421,12 @@ createTestActions opts0 tree = do
         case lookupOption opts of
           Parallel ->
             sequence trees
-          Sequential depType ->
-            snd <$> mapAccumM (goSeqGroup depType) mempty trees
+          FilterableSequential depType -> foldSequential depType trees
+          Sequential depType -> foldSequential depType trees
+
+    foldSequential :: DependencyType -> [Tr] -> ReaderT (Path, Seq Dependency) IO [TestActionTree UnresolvedAction] 
+    foldSequential depType = 
+      fmap snd . mapAccumM (goSeqGroup depType) mempty
 
     -- * Utility functions
     collectTests :: TestActionTree act -> [TestAction act]


### PR DESCRIPTION
This is an attempt to address the use case reported in #445.

# Rationale

There are many scenarios where one would want sequentialTestGroups (as in: don't run these tests in parallel) and _still_ want the ability to filter them, particularly when working on a single test at the bottom of a long sequential group. 
Furthermore, as answered by @Bodigrim, the current behaviour is not obvious from documentation (it is implied by the README in "Dependencies", in a list of caveat about patterns. Adding a dedicated utility for sequential groups that can be filtered make the intent more obvious. I would hazard that the crux of the matter is that two very different concerns were mixed:
- should the test be run in parallel or not;
- are there dependencies between tests;

One could want to have sequential tests _in the absence_ of actual dependencies but simply, for instance, to avoid race conditions. Currently, one has to either use "after" or renounce the ability to filter.

# Constraint

Though ideally the filtering behaviour should be controlled by a specific option and not through the Sequential / Parallel nature of the tests, I couldn't find a way to do it without breaking the current API which I think should be avoided at all costs. Hence the addition of a new constructor for `ExecutionMode`.

I'm not 100% sold on my own proposal, because (a) "filterableSequentialTestGroup" is certainly descriptive but it's a bit too long a name (b) it doesn't clearly separate two very different concerns (c) it leads to some annoying repetition in code (see the changes in `Tast/Run.hs`.

However, it works, changes are little, intent is clear, and it fixes an issue that was raised several times (see also #411).

Considering this issue is rather blocking for me currently, I'm more than willing to apply any requested changes or explore any other direction to have sequential tests be filterable.