### PR TITLE
Bump CI to GHC 9.12, drop GHC 7 support uniformly everywhere

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04]
-        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0', '9.2', '9.4', '9.6', '9.8']
+        os: [ubuntu-latest]
+        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0', '9.2', '9.4', '9.6', '9.8', '9.10', '9.12']
         include:
         - os: macOS-latest
           ghc: 'latest'
@@ -28,10 +28,11 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Install prerequisites for GHC <= 8.2 on ubuntu-22.04
-      if: runner.os == 'Linux' && matrix.ghc <= '8.2'
-      run: |
-        sudo apt-get install libncurses5 libtinfo5
+    # Andreas, 2025-07-26, this step is no longer necessary:
+    # - name: Install prerequisites for GHC <= 8.2 on ubuntu-22.04
+    #   if: runner.os == 'Linux' && matrix.ghc <= '8.2'
+    #   run: |
+    #     sudo apt-get install libncurses5 libtinfo5
 
     - uses: haskell-actions/setup@v2
       id: setup-haskell
@@ -50,11 +51,14 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-ghc-${{ steps.setup-haskell.outputs.ghc-version }}-
 
+    - name: Build
+      run: |
+        cabal build all
+
     - name: Test
       run: |
         set -e
 
-        cabal build all
         cabal install ./core-tests
         export PATH="${HOME}/.cabal/bin:${PATH}"
 

--- a/core/Control/Concurrent/Async.hs
+++ b/core/Control/Concurrent/Async.hs
@@ -175,10 +175,8 @@ data AsyncCancelled = AsyncCancelled
   deriving (Show, Eq, Typeable)
 
 instance Exception AsyncCancelled where
-#if __GLASGOW_HASKELL__ >= 708
   fromException = asyncExceptionFromException
   toException = asyncExceptionToException
-#endif
 
 -- | Cancel an asynchronous action
 --

--- a/core/Test/Tasty/Patterns/Eval.hs
+++ b/core/Test/Tasty/Patterns/Eval.hs
@@ -12,10 +12,6 @@ import Data.List (findIndex, intercalate, isInfixOf, isPrefixOf, tails)
 import Data.Maybe
 import Data.Char
 import Test.Tasty.Patterns.Types
-#if !MIN_VERSION_base(4,9,0)
-import Control.Applicative
-import Data.Traversable
-#endif
 
 -- | @since 1.2
 type Path = Seq.Seq String

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -72,9 +72,6 @@ library
     build-depends:
       unbounded-delays >= 0.1 && < 0.2
 
-  if(!impl(ghc >= 8.0))
-    build-depends: semigroups < 0.21
-
   if(!impl(ghc >= 8.4))
     build-depends: time >= 1.4 && < 1.13
 

--- a/hunit/tasty-hunit.cabal
+++ b/hunit/tasty-hunit.cabal
@@ -13,7 +13,6 @@ author:              Roman Cheplyaka <roma@ro-che.info>
 maintainer:          Roman Cheplyaka <roma@ro-che.info>
 homepage:            https://github.com/UnkindPartition/tasty
 bug-reports:         https://github.com/UnkindPartition/tasty/issues
--- copyright:           
 category:            Testing
 build-type:          Simple
 extra-source-files:  CHANGELOG.md
@@ -29,9 +28,8 @@ library
   other-modules:       Test.Tasty.HUnit.Orig
                        Test.Tasty.HUnit.Steps
   other-extensions:    TypeFamilies, DeriveDataTypeable
-  build-depends:       base >= 4.8 && < 5,
+  build-depends:       base >= 4.9 && < 5,
                        tasty >= 1.2.2 && < 1.6,
                        call-stack < 0.5
-  -- hs-source-dirs:      
   default-language:    Haskell2010
   ghc-options: -Wall

--- a/quickcheck/Test/Tasty/QuickCheck.hs
+++ b/quickcheck/Test/Tasty/QuickCheck.hs
@@ -57,9 +57,6 @@ import Text.Printf
 import Test.QuickCheck.Random (QCGen, mkQCGen)
 import Options.Applicative (metavar)
 import System.Random (getStdRandom, randomR)
-#if !MIN_VERSION_base(4,9,0)
-import Data.Monoid
-#endif
 
 newtype QC = QC QC.Property
   deriving Typeable

--- a/smallcheck/tasty-smallcheck.cabal
+++ b/smallcheck/tasty-smallcheck.cabal
@@ -24,9 +24,9 @@ Library
 
         Build-Depends:          tasty >= 0.8 && < 1.6,
                                 smallcheck >= 1.0 && < 1.3,
-                                base >= 4.8 && < 5,
+                                base >= 4.9 && < 5,
                                 tagged < 0.9,
                                 optparse-applicative < 0.20
-        ghc-options: -Wall -fno-warn-orphans
+        ghc-options: -Wall -Wno-orphans
         default-language: Haskell2010
         default-extensions: CPP


### PR DESCRIPTION
- Drop GHC 7
  GHC 7 is no longer tested by CI.  There were some remnants for GHC 7 (base < 4.9) in the codebase which I removed.
  
- CI: add GHC 9.10 and 9.12, bump to ubuntu-latest.
  I also isolated `cabal build all` as an extra step.  More fine-grained step help with reading the CI output.
  