### PR TITLE
Separate modules in Cabal files with newlines (not commas)

### DIFF
--- a/core-tests/core-tests.cabal
+++ b/core-tests/core-tests.cabal
@@ -21,11 +21,15 @@ common commons
 executable tasty-core-tests
   import:              commons
   main-is:             test.hs
-  other-modules:       Resources, Timeouts, Utils, AWK, Dependencies, DependentTestGroup
-  -- other-extensions:
+  other-modules:
+    Resources
+    Timeouts
+    Utils
+    AWK
+    Dependencies
+    DependentTestGroup
   build-depends:       base >= 4.9 && <= 5, tasty, tasty-hunit, tasty-golden, tasty-quickcheck, containers, stm, mtl,
                        filepath, bytestring, optparse-applicative, random
-  -- hs-source-dirs:
   default-extensions:  CPP, NumDecimals
   ghc-options:         -Wall -fno-warn-type-defaults -fno-warn-name-shadowing -fno-warn-incomplete-uni-patterns
 

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -29,12 +29,12 @@ flag unix
 
 library
   exposed-modules:
-    Test.Tasty,
-    Test.Tasty.Options,
-    Test.Tasty.Providers,
-    Test.Tasty.Providers.ConsoleFormat,
+    Test.Tasty
+    Test.Tasty.Options
+    Test.Tasty.Providers
+    Test.Tasty.Providers.ConsoleFormat
     Test.Tasty.Runners
-    Test.Tasty.Ingredients,
+    Test.Tasty.Ingredients
     Test.Tasty.Ingredients.Basic
     Test.Tasty.Ingredients.ConsoleReporter
 
@@ -45,16 +45,16 @@ library
     Test.Tasty.Patterns.Eval
   other-modules:
     Control.Concurrent.Async
-    Test.Tasty.Parallel,
-    Test.Tasty.Core,
-    Test.Tasty.Options.Core,
-    Test.Tasty.Options.Env,
-    Test.Tasty.Patterns,
-    Test.Tasty.Patterns.Expr,
-    Test.Tasty.Run,
-    Test.Tasty.Runners.Reducers,
-    Test.Tasty.Runners.Utils,
-    Test.Tasty.CmdLine,
+    Test.Tasty.Parallel
+    Test.Tasty.Core
+    Test.Tasty.Options.Core
+    Test.Tasty.Options.Env
+    Test.Tasty.Patterns
+    Test.Tasty.Patterns.Expr
+    Test.Tasty.Run
+    Test.Tasty.Runners.Reducers
+    Test.Tasty.Runners.Utils
+    Test.Tasty.CmdLine
     Test.Tasty.Ingredients.ListTests
     Test.Tasty.Ingredients.IncludingOptions
 


### PR DESCRIPTION
Currently it's inconsistent: `tasty.cabal` uses both newlines and commas in the same fields. Let's use newlines uniformly.