### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Available options:
   --quickcheck-max-size NUMBER
                            Size of the biggest test cases quickcheck generates
   --quickcheck-max-ratio NUMBER
-                           Maximum number of discared tests per successful test
+                           Maximum number of discarded tests per successful test
                            before giving up
   --quickcheck-verbose     Show the generated test cases
   --quickcheck-shrinks NUMBER

--- a/core-tests/DependentTestGroup.hs
+++ b/core-tests/DependentTestGroup.hs
@@ -257,7 +257,7 @@ checkResult fullTree resultM =
         -- not in any of the trees in 'trees'.
         result1 = filter (inRange r) result0
 
-        -- Note that 'result' is preprended during test execution, so tests that
+        -- Note that 'result' is prepended during test execution, so tests that
         -- ran last appear first. Hence, we reverse the tree list when matching
         -- on 'Dependently'.
         (_, results) = mapAccumL goResult result1 trees

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -521,7 +521,7 @@ Version 0.6
 * Better handling of exceptions that arise during resource creation or
   disposal
 * Expose the `AppMonoid` wrapper
-* Add `askOption` and `inludingOptions`
+* Add `askOption` and `includingOptions`
 
 Version 0.5.2.1
 ---------------

--- a/core/Test/Tasty/Core.hs
+++ b/core/Test/Tasty/Core.hs
@@ -448,7 +448,7 @@ after deptype s =
 --
 -- Instead of constructing fresh records, build upon `trivialFold`
 -- instead. This way your code won't break when new nodes/fields are
--- indroduced.
+-- introduced.
 --
 -- @since 0.7
 data TreeFold b = TreeFold

--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -845,7 +845,7 @@ output format = withConsoleFormat format . putStr
 -- line or console detection.
 --
 -- Can be used by providers that wish to provider specific result details printing,
--- while re-using the tasty formats and coloring logic.
+-- while reusing the tasty formats and coloring logic.
 --
 -- @since 1.3.1
 withConsoleFormat :: (?colors :: Bool) => ConsoleFormatPrinter

--- a/core/Test/Tasty/Providers/ConsoleFormat.hs
+++ b/core/Test/Tasty/Providers/ConsoleFormat.hs
@@ -1,5 +1,5 @@
 -- | This module can be used by providers to perform colorful/formatted
--- output and possibly re-use tasty's own output formats.
+-- output and possibly reuse tasty's own output formats.
 --
 -- @since 1.3.1
 module Test.Tasty.Providers.ConsoleFormat
@@ -68,13 +68,13 @@ failFormat = ConsoleFormat BoldIntensity   Vivid Red
 infoFailFormat :: ConsoleFormat
 infoFailFormat = ConsoleFormat NormalIntensity Dull  Red
 
--- | Format used to display sucesses
+-- | Format used to display successes
 --
 -- @since 1.3.1
 okFormat :: ConsoleFormat
 okFormat = ConsoleFormat NormalIntensity Dull  Green
 
--- | Format used to display additional information on sucesses
+-- | Format used to display additional information on successes
 --
 -- @since 1.3.1
 infoOkFormat :: ConsoleFormat

--- a/core/Test/Tasty/Run.hs
+++ b/core/Test/Tasty/Run.hs
@@ -134,7 +134,7 @@ executeTest action statusVar timeoutOpt hideProgressOpt inits fins = mask $ \res
       timed $ applyTimeout timeoutOpt $ do
         r <- wait asy
         -- Not only wait for the result to be returned, but make sure to
-        -- evalute it inside applyTimeout; see #280.
+        -- evaluate it inside applyTimeout; see #280.
         evaluate $
           resultOutcome r `seq`
           forceElements (resultDescription r) `seq`
@@ -287,7 +287,7 @@ isPatternDependency _ = False
 -- The mapAccumM function behaves like a combination of mapM and mapAccumL that
 -- traverses the structure while evaluating the actions and passing an accumulating
 -- parameter from left to right. It returns a final value of this accumulator
--- together with the new structure. The accummulator is often used for caching the
+-- together with the new structure. The accumulator is often used for caching the
 -- intermediate results of a computation.
 mapAccumM :: Monad m => (acc -> x -> m (acc, y)) -> acc -> [x] -> m (acc, [y])
 mapAccumM _ acc [] = return (acc, [])

--- a/hunit/Test/Tasty/HUnit/Orig.hs
+++ b/hunit/Test/Tasty/HUnit/Orig.hs
@@ -24,7 +24,7 @@ import Data.CallStack
 
 type Assertion = IO ()
 
--- | Unconditionally signals that a failure has occured.  All
+-- | Unconditionally signals that a failure has occurred.  All
 -- other assertions can be expressed with the form:
 --
 -- @

--- a/quickcheck/Test/Tasty/QuickCheck.hs
+++ b/quickcheck/Test/Tasty/QuickCheck.hs
@@ -161,7 +161,7 @@ instance IsOption QuickCheckMaxRatio where
   showDefaultValue (QuickCheckMaxRatio n) = Just (show n)
   parseValue = fmap QuickCheckMaxRatio . safeRead
   optionName = return "quickcheck-max-ratio"
-  optionHelp = return "Maximum number of discared tests per successful test before giving up"
+  optionHelp = return "Maximum number of discarded tests per successful test before giving up"
   optionCLParser = mkOptionCLParser $ metavar "NUMBER"
 
 instance IsOption QuickCheckVerbose where


### PR DESCRIPTION
Found via `codespell -L unio,testng,ot,fo`