### PR TITLE
Compatibility with optparse-applicative HEAD

### DIFF
--- a/core/Test/Tasty/CmdLine.hs
+++ b/core/Test/Tasty/CmdLine.hs
@@ -154,9 +154,7 @@ parseOptions ins tree = do
   mapM_ (hPutStrLn stderr) warnings
   cmdlineOpts <- execParser $
     info (helper <*> parser)
-    ( fullDesc <>
-      header "Mmm... tasty test suite"
-    )
+    (header "Mmm... tasty test suite")
   envOpts <- suiteEnvOptions ins tree
   return $ envOpts <> cmdlineOpts
 


### PR DESCRIPTION
https://github.com/pcapriotti/optparse-applicative/blob/db1bf6556afbe8f2a238b811fcd303f4541900c7/CHANGELOG.md says:
```
## Version 0.20.0.0 (Unreleased)
...
- Remove `fullDesc` and `briefDesc` builder modifiers – they have not had an
  effect since version 0.8.
```

We don't have to wait until `optparse-applicative-0.20` gets released, we can scrap no-op `fullDesc` already.