### PR TITLE
quickcheck: do not re-export TemplateHaskell functions polyQuickCheck, polyVerboseCheck and monomorphic

### DIFF
--- a/quickcheck/CHANGELOG.md
+++ b/quickcheck/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Version 0.12
+------------
+
+* Do not re-export TemplateHaskell functions
+  `polyQuickCheck`, `polyVerboseCheck` and `monomorphic`.
+
 Version 0.11.1
 --------------
 

--- a/quickcheck/Test/Tasty/QuickCheck.hs
+++ b/quickcheck/Test/Tasty/QuickCheck.hs
@@ -42,12 +42,13 @@ import Test.QuickCheck hiding -- for re-export
   , verboseCheckResult
   , verbose
   -- Template Haskell functions
-#if MIN_VERSION_QuickCheck(2,11,0)
   , allProperties
-#endif
   , forAllProperties
   , quickCheckAll
   , verboseCheckAll
+  , polyQuickCheck
+  , polyVerboseCheck
+  , monomorphic
   )
 
 import Control.Applicative

--- a/quickcheck/tasty-quickcheck.cabal
+++ b/quickcheck/tasty-quickcheck.cabal
@@ -1,5 +1,5 @@
 name:                tasty-quickcheck
-version:             0.11.1
+version:             0.12
 synopsis:            QuickCheck support for the Tasty test framework.
 description:         QuickCheck support for the Tasty test framework.
                      .
@@ -26,7 +26,7 @@ library
                        tagged < 0.9,
                        tasty >= 1.5.1 && < 1.6,
                        random < 1.4,
-                       QuickCheck >= 2.10 && < 2.19,
+                       QuickCheck >= 2.11 && < 2.19,
                        optparse-applicative < 0.20
 
   default-language:    Haskell2010


### PR DESCRIPTION
The intention of 
https://github.com/UnkindPartition/tasty/blob/349a06021db9f4acbc54040c973a47fcd69d87d6/quickcheck/Test/Tasty/QuickCheck.hs#L31-L51
was not re-exporting TemplateHaskell functions originating from [`Test.QuickCheck.All`](https://hackage-content.haskell.org/package/QuickCheck-2.18.0.0/docs/Test-QuickCheck-All.html). Yet we missed a moment when this module grew and started exporting more stuff. This is technically a breaking change.

(I intent to switch to explicit re-exports so this situation does not happen again, but will do it in a separate commit)