### PR TITLE
Release tasty-1.5.4

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,6 +1,26 @@
 Changes
 =======
 
+Version 1.5.4
+--------------
+
+_2025-03-31_
+
+* Fix display of `HasCallStack` backtraces when a test throws an error
+  ([#472](https://github.com/UnkindPartition/tasty/pull/472)).
+* Introduce `dependentTestGroup` and `inOrderTestGroup`,
+  deprecate `sequentialTestGroup`
+  ([#448](https://github.com/UnkindPartition/tasty/pull/448)).
+* Add `instance IsTest t => IsTest (ContT () IO t)`
+  ([#466](https://github.com/UnkindPartition/tasty/pull/466)).
+* Limit maximum line length in console reporter
+  ([#451](https://github.com/UnkindPartition/tasty/pull/451)).
+* Make `-j` to entail `+RTS -N` automatically
+  ([#457](https://github.com/UnkindPartition/tasty/pull/457)).
+* Do not depend on `unbounded-delays` on `ppc64le` and `loongarch64`
+  ([#460](https://github.com/UnkindPartition/tasty/pull/460),
+   [#465](https://github.com/UnkindPartition/tasty/pull/465)).
+
 Version 1.5.3
 --------------
 

--- a/core/Test/Tasty/Core.hs
+++ b/core/Test/Tasty/Core.hs
@@ -240,6 +240,7 @@ class Typeable t => IsTest t where
   -- | The list of options that affect execution of tests of this type
   testOptions :: Tagged t [OptionDescription]
 
+-- | @since 1.5.4
 instance IsTest t => IsTest (ContT () IO t) where
   testOptions = coerce (testOptions @t)
   run opts (ContT k) yieldProgress = do

--- a/core/tasty.cabal
+++ b/core/tasty.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                tasty
-version:             1.5.3
+version:             1.5.4
 synopsis:            Modern and extensible testing framework
 description:         Tasty is a modern testing framework for Haskell.
                      It lets you combine your unit tests, golden


### PR DESCRIPTION
`tasty-1.5.3` is more than a year old, so I think it's time for a new release of `tasty`.