### PR TITLE
Get terminal width from COLUMNS environment variable for quicker turnaround

### DIFF
--- a/core/Test/Tasty/Ingredients/ConsoleReporter.hs
+++ b/core/Test/Tasty/Ingredients/ConsoleReporter.hs
@@ -49,6 +49,7 @@ import Test.Tasty.Patterns.Types
 import Test.Tasty.Runners.Reducers
 import Test.Tasty.Runners.Utils
 import Text.Printf
+import Text.Read (readMaybe)
 import qualified Data.IntMap as IntMap
 import qualified Data.IntSet as IntSet
 import Data.Char
@@ -61,6 +62,7 @@ import Data.Monoid (Any(..))
 import qualified Data.Semigroup as Sem
 import Data.Typeable
 import Options.Applicative hiding (action, str, Success, Failure)
+import System.Environment (lookupEnv)
 import System.IO
 import System.Console.ANSI
 #if !MIN_VERSION_base(4,11,0)
@@ -133,9 +135,17 @@ type Level = Int
 terminalWidth :: Maybe Int
 terminalWidth = unsafePerformIO $ do
   isTerminalStdin <- hIsTerminalDevice stdin
-  if isTerminalStdin
-  then fmap (fmap snd) getTerminalSize
-  else pure Nothing
+  result <-
+    if isTerminalStdin
+    then do
+      mcols <- lookupEnv "COLUMNS"
+      case readMaybe =<< mcols of
+        size@(Just size')
+          | size' > 0
+          -> pure size
+        _ -> fmap (fmap snd) getTerminalSize
+    else pure Nothing
+  pure result
 {-# NOINLINE terminalWidth #-}
 
 -- | How wide could 'resultShortDescription' be (in non-extreme scenarios)?


### PR DESCRIPTION
I propose to speed up obtaining of terminal dimensions in the common case when running under bash by reading `COLUMNS` environment variable and defaulting to the current method if it's not available.

The motivation is that in some tasty clients the `getTerminalSize` call is unreasonably slow with no good way of working around that I'm aware of.

To illustrate the issue consider following program that just gets the terminal size:
```haskell
#!/usr/bin/env -S cabal run
{- cabal:
default-language:
  GHC2024
build-depends:
  , ansi-terminal
  , base
-}

import System.Console.ANSI
import System.IO

main :: IO ()
main = do
  size <- getTerminalSize
  print size
  hFlush stdout
  pure ()
```

When running under standard KDE Konsole terminal emulator it works imperceptibly fast, which is OK
```
sergey@home:/tmp/tmp/tmp$ time cabal run TestTerminal.hs
Just (28,100)

real    0m0.035s
user    0m0.021s
sys     0m0.014s
sergey@home:/tmp/tmp/tmp$ time cabal run TestTerminal.hs
Just (28,100)

real    0m0.031s
user    0m0.019s
sys     0m0.012s
sergey@home:/tmp/tmp/tmp$ time cabal run TestTerminal.hs
Just (28,100)

real    0m0.033s
user    0m0.024s
sys     0m0.009s
```

But when running under vanilla Emacs in `M-x shell` it gets noticeably slower:
```
sergey@home:/tmp/tmp/tmp$ time cabal run TestTerminal.hs
78Nothing

real	0m0.537s
user	0m0.032s
sys	0m0.006s
sergey@home:/tmp/tmp/tmp$ time cabal run TestTerminal.hs
78Nothing

real	0m0.535s
user	0m0.023s
sys	0m0.012s
sergey@home:/tmp/tmp/tmp$ time cabal run TestTerminal.hs
78Nothing

real	0m0.535s
user	0m0.020s
sys	0m0.015s
```

Nevermind the `78` garbage, that can be filtered out by users, and the fact that size is Nothing, which is less important under Emacs. The 0.5 seconds delay is perceptible and I'd like it to go awy. Unfortunately I cannot really tell where it's coming from, looks like the reading from stdin, which `getTerminalSize` does under the hood, might be responsible.

So the idea is to speed up the operation at least when running under `bash` which sets two environment variables for the purposes of detecting terminal geometry, `LINES` and `COLUMNS`:

```
sergey@home:/tmp/tmp/tmp$ echo $COLUMNS
100
```

It seems making use of `COLUMNS` if it's available would do no harm but would really help poor Emacs users among which I have dubious honor to be included.